### PR TITLE
Page view tracking

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -918,9 +918,9 @@ which the Learning Activity Provider may or may not include in the statement.
 	<tr>
 		<td>score</td>
 		<td>Score object. See <a href="#score">section 4.1.5.1</a>.</td>
-		<td>The score of the agent in the activity in relation to the success of the activity.
+		<td>The score of the agent in relation to the success or quality of the experience.
 		For example: quiz scores, success at a task. This property SHOULD NOT be used for
-		scores relating to progress or completion. Consider using an extension from the CMI5
+		scores relating to progress or completion. Consider using an extension from an extension
 		profile instead.
 		</td>
 	</tr>


### PR DESCRIPTION
I have a use case on a real live project to report both 
page progress and score for a SCORM-style course. I imagine 
this is a common use case. I'm surprised this hasn't come up 
before actually. 

I think the solution proposed is quite neat and simple. I don't
think an extension would be appropriate for something so common.
