### PR TITLE
Major query overhaul

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -1922,7 +1922,7 @@ Returns: 200 OK, statement or [Statement Result](#retstmts) (See section 4.2 for
 	</tr>
 	<tr><td>related_agents</td><td>Boolean</td><td>False</td>
 		<td>Apply the agent filter broadly. Include statements for which 
-			the actor, object, authority, instructor, team, agents listed as part of a team,
+			the actor, object, authority, instructor, team,
 			or any of these properties in a contained SubStatement match the agent parameter,
 			instead of that parameter's normal behavior. Matching is defined in the same way
 			it is for the 'agent' parameter.


### PR DESCRIPTION
- pulled in voided query change from @garemoko
- clarified that the multipart attachment format is to be used in responses when attachments are requested even if there are no attachments.
- simplified existing query options while expanding them. (see extensive changes)
- targeted statement search clarification
- Moved single-statement queries in to the main query parameter block in order to allow "attachments" and "format" to apply
- added "voidedStatementId" to allow fetching voided statements

Justifications
- The query parameter shuffle is based on the discussion around the purpose of the query API. It allows for more general types of statements to be filtered out and simplifies the query parameters conceptually. It is based on the idea that the LRS query facility is not appropriate for driving a reporting UI directly.
- voided changes as discussed

Related issues:
https://github.com/adlnet/xAPI-Spec/pull/85
https://github.com/adlnet/xAPI-Spec/issues/76
https://github.com/adlnet/xAPI-Spec/issues/28
