### PR TITLE
Make statement ID a SHOULD for activity providers

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -403,7 +403,8 @@ See [Appendix D: Example statements](#AppendixD) for more examples.
 ### 4.1.1 ID:  
 
 #####Description: 
-A UUID.
+A UUID (see [RFC 4122](http://www.ietf.org/rfc/rfc4122.txt)
+for requirements, and the UUID must be in standard string form).
 
 #####Details: 
 


### PR DESCRIPTION
Not sending the ID can lead to problems, since POSTing statements without IDs is not idempotent. Because of that, I think we should upgrade sending it by the activity provider to a SHOULD. Libraries for generating UUIDs are widely available in all major programming languages. Also includes reference to the relevant RFC and the exact format required (should we elaborate more? there's only one standard format, but there are a number of lesser variations).
