### PR TITLE
Remove objectType from actor in MUST/SHOULD minimal example

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -382,7 +382,6 @@ Simplest possible statement using all properties that MUST or SHOULD be used:
 ```
 {
 	"actor":{
-		"objectType": "Agent",
 		"mbox":"mailto:xapi@adlnet.gov"
 	},
 	"verb":{


### PR DESCRIPTION
Since it isn't a MUST or SHOULD in that location
