### PR TITLE
fix: remove lines that should have been removed in query PR

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -2001,11 +2001,6 @@ Returns: 200 OK, statement or [Statement Result](#retstmts) (See section 4.2 for
 	</tr>
 	<tr><td>activity</td><td>Activity id (URI)</td><td> </td>
 		<td>Filter, only return statements for which the object of the statement is an activity with the specified id.
-			(activity or agent/group).<br/><br/>
-			Object is an activity: return statements with an object that is an 
-			activity with a matching activity ID to the specified activity.<br/><br/>
-			Object is an agent or group: same behavior as "actor" filter, except match 
-			against object property of statements.
 		</td>
 	</tr>
 	<tr><td>registration</td><td>UUID</td><td> </td>


### PR DESCRIPTION
The query overhaul removed the overloading of the "object" query parameter as either agent or activity, and
this was understood by reviewers -- these lines make no sense here and should have been deleted.

I think everyone missed this on review because these lines weren't added or removed.
