### PR TITLE
Conversion fixes -- ALSO REVIEW: all of Appendix E

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -3060,8 +3060,8 @@ A 1.0 system converting a statement created in 0.9 MUST follow the steps below:
 * If the statement has been voided or uses verbs, activity types, or properties not included in the
  0.9 specification, do not convert it.
 * Prefix "verb" with "http://adlnet.gov/expapi/verbs/".
-* Prefix any activity ids which are not a full absolute URIs with "urn:expapi:0.9:activities:"
-* Prefix any extension keys which are not a full absolute URIs with "urn:expapi:0.9:extensions:"
+* Prefix any activity ids which are not full absolute URIs with "urn:expapi:0.9:activities:"
+* Prefix any extension keys which are not full absolute URIs with "urn:expapi:0.9:extensions:"
 * Prefix activity types with "http://adlnet.gov/expapi/activities/"
 * for each agent (actor):
     * Search for inverse functional identifiers in this order: "mbox, mbox_sha1sum, openId,


### PR DESCRIPTION
- Addressed some invalid 0.9 statements
- Added conversion for non-URI extension keys

Note!: Appendix E got merged before it was fully reviewed, please have a look at the entire appendix if  you haven't yet.

Some points for discussion brought up so far:
- Invalid 0.9 statements, especially those using verbs or activity types not defined in the ADL list. (has this been sufficiently / properly addrssed?)
- agents that have a first name and last name - should name be calculated?
- should use of "urn:expapi:0.9:activities:" be restricted to converted 0.9 statements.
- are we OK with using a urn: prefix with our made-up post-urn scheme? would we rather use a URL that won't resolve?
