### PR TITLE
Moved inverse functional identifiers into their own sub-section

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -504,8 +504,8 @@ in a given anonymous or identified Group.
 <a name="inversefunctional">
 ##### 4.1.2.3 Inverse Functional Identifier
 ###### Details: 
-An "inverse functional identifier" is a value shared between multiple agents or identified
-groups that designates themas the same unique identity without doubt.
+An "inverse functional identifier" is a value of agents or identified
+groups that is guaranteed to only ever refer to that agent or identified group.
 
 ###### Rationale:
 Learning experiences become meaningless if they cannot be attributed to identifiable


### PR DESCRIPTION
This change started as an attempt to clarify that actors do NOT require inverse functional identifiers, rather they require a valid agent or group -- which in turn require inverse functional identifiers except for anonymous groups. In order to help clarify that I gave inverse functional identifiers their own sub-section, since talking about IFI's being required in the actor section makes it sound like they're required for all actors.
