### PR TITLE
Added signed statements section & example

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -55,7 +55,7 @@
 [Appendix B: Creating an "IE Mode" Request](#AppendixB)  
 [Appendix C: Example definitions for activities of type "cmi.interaction"](#AppendixC)  
 [Appendix D: Example statements](#AppendixD)  
-[Appendix E: Converting Statements to 1.0](#AppendixE)
+[Appendix E: Converting Statements to 1.0](#AppendixE)   
 [Appendix F: Example Signed Statement](#AppendixF)
 
 <a name="revhistory"/>  
@@ -3387,6 +3387,7 @@ lBRK8g7ZncekbGW3aRLVGVOxClnLLTzwOlamBKOUm8V6XxsMHQ6TE2D+fKJoNUY1
 ```
 
 Example public X.509 certificate
+```
 -----BEGIN CERTIFICATE-----
 MIIDATCCAmqgAwIBAgIJAMB1csNuA6+kMA0GCSqGSIb3DQEBBQUAMHExCzAJBgNV
 BAYTAlVTMRIwEAYDVQQIEwlUZW5uZXNzZWUxGDAWBgNVBAoTD0V4YW1wbGUgQ29t


### PR DESCRIPTION
Discussion points / differences from original proposal
- referenced a signature 'attachmentUsage' uri, if ADL does not want to own this we need to find another home: "http://adlnet.gov/expapi/attachments/signature"
- restricted algorithm to RSA + SHA2 (with key/hash length options) for interoperability
- requirement that X.509 certificates SHOULD be used, as this allows embedding information about the signer and including the public key
- added LRS requirements for validation -- to reject mistakes, not as a security measure
