### PR TITLE
remaining 1.0.0 refs

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -1909,7 +1909,7 @@ Converting statements to other versions:
 
 * Systems MUST NOT convert statements of newer versions into a prior version format e.g. in order to handle version differences.
 * Systems MAY convert statements of older versions into a newer version only by following the methods described in
-<a href="#AppendixE">Appendix E: Converting Statements to 1.0</a>.
+<a href="#AppendixE">Appendix E: Converting Statements to 1.0.0</a>.
 
 <a name="concurrency"/> 
 ### 6.3 Concurrency:
@@ -2763,7 +2763,7 @@ Returns: 200 OK - Single 'about' JSON document.
 </table>
 
 ###### LRS Requirements:
-* MUST return the JSON document describe above, with a version property of "1.0"
+* MUST return the JSON document described above, with a version property of "1.0.0"
 * SHOULD allow unauthenticated access to this resource
 * MUST NOT reject requests based on their version header as would otherwise be required
 by <a href="#apiversioning"/>6.2 API Versioning</a>.


### PR DESCRIPTION
changed 2 places where we said 1.0 instead of 1.0.0, fixed a typo

@andyjohnson trivial, please merge
