### PR TITLE
Formatting for Table of Contents and Technical Edits

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -228,14 +228,17 @@ Experience API specification.
 
 ### 2.3 Reading guidelines for the non-technically inclined.
 
-Since you’re reading this document, it’s probably safe to say that you’re interested in understanding 
-the Experience API (xAPI), informally called the "Tin Can API". The purpose of this document is to describe how the xAPI is 
-implemented in a large variety of systems. It’s a fairly technical document by nature and you may
-decide that you don’t understand much of it. Even so, there are useful things to learn by reading further. Not only
-because the tools that you work with are based on the specifications described below; the technical people that you
-talk to may assume that you have a basic level of knowledge. For this reason you’re advised to read the small
-sections labeled ‘description’ and ‘rationale’ while skipping the ‘details’ and ‘examples’. Needless to say, many
-other sources can be found that explain xAPI very well, but this document is the core of them all.
+This is a definitive document which describes how the Experience API is to be implemented
+across a variety of systems. It is a technical document authored specifically for individuals 
+and organizations implementing this technology with the intent of such individuals 
+developing interoperable tools, systems and services that are independent of each other 
+and interoperable with each other. 
+
+Whenever possible, the language and formatting used in this document is intended to be 
+_considerate_ of non-technical readers because various tools, systems and services 
+are based on the specification set described below. For this reason, sections that provide a 
+_high-level overview_ of a given facet of the Experience API are labeled **description** or 
+**rationale**. Items in this document labeled as **details** or **examples** are more technical. 
 
 <a name="defintions"/> 
 ## 3.0 Definitions  


### PR DESCRIPTION
Using bullets appropriately with tabs, I'm able to properly nest the headings and various subheadings appropriately in the table of contents, which makes the table of contents more usable and useful.

I also removed the listing in the table of contents for "Tin Can API" as it was the _only_ definition specifically called out in the table of contents and it had no actual section or subsection identifier.

I've also made an edit to the language of Section 2.2.2, as was suggested by Heather Walls, ADL Technical Editor, and Section 2.3, as was identified for edits in the 18 April technical review by ADL.
