### PR TITLE
Updated Section 3.0 Definitions 

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -258,8 +258,11 @@ other sources can be found that explain xAPI very well, but this document is the
 * [Verb](#def-verb)
 
 <a name="def-activity" />
-__Activity__: : An activity can be a unit of instruction, experience, or performance that is to 
-be tracked used Statements in a meaningful combination with an Actor and a Verb. 
+__Activity__: A thing with which to be interacted. An Activity can be a unit of 
+instruction, experience, or performance that is to be tracked in meaningful combination with a Verb. 
+Interpretation of ‘Activity’ is broad, meaning that Activities can even be tangible objects. In the statement
+"Anna tried a cake recipe”: the recipe constitutes the Activity in terms of the xAPI statement.
+Other examples include a book, an e-learning course, a hike or a meeting. 
 
 <a name="def-activity-provider" />
 __Activity Provider (AP)__: The software object that is communicating with 


### PR DESCRIPTION
Fixed typos in TCAPI,MUST/SHOULD/MAY, and IFI tags and a couple redundancies in definitions.  

Renamed Learning Activity Provider to just Activity Provider as we don't have a common pattern for learning experiences, etc. throughout.  

Shortened some definitions to lessen "fluff".  The sections themselves provide more information.  

Re-defined activity to move away from "thing".  Confusing in the definition and never clarified later.  Used with Verb and Actor, which are introduced.

Updated URI to IRI.  Kept language.  I'm not as familiar with IRIs, so verify the meaning still works.

Completely re-defined LMS.

Removed "State" definition as it was the only API mentioned.  

Removed references to sections as it seems backwards for the definitions to refer to the document.
