### PR TITLE
Accept 1.0 as 1.0.0

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -2046,6 +2046,7 @@ Requirements for the LRS:
 
 * MUST include the "X-Experience-API-Version" header in every response;
 * MUST set this header to ""1.0.0"";
+* MUST accept requests with a version header of "1.0" as if the version header was "1.0.0";
 * MUST reject requests with version header prior to "1.0.0" unless such requests are routed to a fully conformant implementation of the prior version specified in the header;
 * MUST reject requests with a version header of "1.1.0" or greater;
 * MUST make these rejects by responding with an HTTP 400 error including a short description of the problem.


### PR DESCRIPTION
The spec has been talked about as 1.0 for a long time, and we've been shooting for (and succeeding) to allow 0.95 clients to continue to send statements with only an updated version header -- but we'd previously talked about updating it to 1.0.

If even a few pieces of content out there have done tried already (which they could have done before any 1.0(.0) systems exist by trying the 1.0 version header and falling back to 0.95 if rejected), it will be worth LRSs accepting 1.0 as 1.0.0. I don't see a downside, if one were to map 1.0 onto our new version scheme 1.0.0 is a logical equivalent.
