### PR TITLE
Statement reference fix

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -1286,7 +1286,7 @@ applicable and known.
 </tr>
 <tr>
 <td>statement</td>
-<td>[Statement Reference](#stmtref)</td>
+<td><a href="#stmtref">Statement Reference</a></td>
 <td>Another Statement, which should be considered as context for this Statement. </td>
 
 </tr>


### PR DESCRIPTION
The link to Statement Reference in the context properties table was done in markdown rather than html. Markdown within tables doesn't render, so I replaced this with an html link. 

This doesn't change the meaning and should be non-controversial for 1.0.1
