### PR TITLE
Changing extension key type from IRL to IRI.

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -1968,7 +1968,7 @@ Extensions are defined by a map. The keys of that map MUST be IRIs, and the
 values MAY be any JSON value or data structure. The meaning and structure of 
 extension values under an IRI key are defined by the person who coined the IRI, 
 who SHOULD be the owner of the IRI, or have permission from the owner. If the
-extension is an IRL, the owner of the IRL SHOULD make a human-readable description
+extension key is an IRL, the owner of the IRL SHOULD make a human-readable description
 of the intended meaning of the extension supported by the IRL accessible at the IRL.
 A learning record store  MUST NOT reject an Experience API Statement based on the
 values of the extensions map.


### PR DESCRIPTION
This is possibly contentious but should probably be addressed.

Although the extension section defines each key as an IRL, [Appendix F](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI.md#conversion-of-statements-created-based-on-version-09) indicates 0.9 extensions should be tagged as IRIs. So as to not break any already-converted extensions, I'd propose this backwards-compatible change to make extension keys IRIs.

Thoughts?
