### PR TITLE
Section 5 Edits/Formatting

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -1955,12 +1955,6 @@ in this specification do. The id is stored in the IRL, "updated" is HTTP header 
 	<tr><td>contents</td><td>Arbitrary binary data</td><td>The contents of the document</td></tr>
 </table>
 
-##### Requirements
-
-* An LRS stored document key consisting of a combination of agent, activity, or agent-activity(-registration)
-MUST NOT collide with any other key with another stored agent, activity, or agent-activity(-registration) 
-combination.
-
 <a name="misclangmap"/>
 
 ### 5.2 Language Map


### PR DESCRIPTION
I think this was the hardest section to re-write.  A lot of pieces moved here, especially in 5.3 from the State API (or so it seems).  Please read each section for meaning, not just what has changed.  Some requirements were re-written to get at intent and keeping a requirement intact, even though a later version may remove a requirement.  I didn't want to risk pushing this version to a 1.1.

I removed the "coined" language as well as ownership around it.  Seems to me that verbs get created and controlled rather than coined and owned.  Less rules around ownership as well.

I'd also like everyone to look at the last "requirement" in 5.4:

Other sources of information MAY be used to fill in missing details, such as translations, or take the place of this metadata entirely if it was not provided or cannot be loaded. This MAY
include metadata in other formats stored at the IRL of an identifier, particularly if that
identifier was not coined for use with this specification.

~ Are we saying this ONLY if the IRI isn't provided or loaded?  To me this should probably just be re-written into the details.  I'll likely edit this bullet again, but wanted to get a general take on it before I risk butchering it.  
