### PR TITLE
Appendix A: wrong example statement using bookmarklet

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -3204,7 +3204,7 @@ definition.type = "http://adlnet.gov/expapi/activities/link";
 
 var xhr = new XMLHttpRequest();
 xhr.open("PUT", url, true);
-xhr.setRequestHeader("X-Experience-API-Version", "1.0");
+xhr.setRequestHeader("X-Experience-API-Version", "1.0.0");
 xhr.setRequestHeader("Content-Type", "application/json");
 xhr.setRequestHeader("Authorization", auth);
 xhr.onreadystatechange = function() {
@@ -3235,7 +3235,7 @@ function _ruuid() {
 ###### Headers  
 ```
 {
-	"X-Experience-API-Version": "1.0",
+	"X-Experience-API-Version": "1.0.0",
 	"Content-Type": "application/json",
 	"Authorization": "Basic dGVzdDpwYXNzd29yZA==",
 	"Referer": "http://adlnet.gov/xapi/",


### PR DESCRIPTION
 Note: f71cfdc6a5b4ca823f13f2b7e5be6677d112084e could start a discussion about adopting the UTF-8 encoding for xAPI. Not sure if really required: [RFC 4627](http://tools.ietf.org/html/rfc4627#section-3) is IMHO clear enough in describing the discovering of the used encoding for the JSON payload.
