### PR TITLE
SHA-2 type is not "base64": better a string of 64 (SHA-256) hex digits (hexits).

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -1583,7 +1583,7 @@ The table below lists all properties of the Attachment Object.
 	</tr>
 	<tr>
 		<td>length</td>
-		<td>integer</td>
+		<td>Integer</td>
 		<td>The length of the attachment data in octets</td>
 		<td>yes</td>
 	</tr>


### PR DESCRIPTION
_SHA-2_ for `here is a simple attachment` is:

`495395e777cd98da653df9615d09c0fd6bb2f8d4788394cd53c56a3bfdcd848a`

as written in the example few lines below while a _Base64_ representation of that hash is:

`NDk1Mzk1ZTc3N2NkOThkYTY1M2RmOTYxNWQwOWMwZmQ2YmIyZjhkNDc4ODM5NGNkNTNjNTZhM2JmZGNkODQ4YQ==`

Maybe, that type has been written thinking at a possible encoding method for the binary part of the multipart payload.
