### PR TITLE
Openid capitalisation

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -754,7 +754,7 @@ _Language_
 A Verb in the Experience API is an IRI, and denotes a specific meaning not tied to any particular language. 
 
 For example, a particular Verb IRI such as http://example.org/firearms#fire might denote the action of firing a gun, 
-or the Verb IRI http://example.com/???/?????? might denote the action of reading a book. 
+or the Verb IRI http://example.com/فعل/خواندن might denote the action of reading a book. 
 
 ##### 4.1.3.2 Use in Communities of Practice
 


### PR DESCRIPTION
Fixes https://github.com/adlnet/xAPI-Spec/issues/330

Note that some instances of openID remain e.g the second occurrence on line 621 shown in the diff. These are correct when talking about openIDs as a thing, rather than the openid property. We're following a similar approach on line 620 already. 
