### PR TITLE
return values as code blocks in section 7 

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -2444,7 +2444,7 @@ or the method to retrieve a single Statement.
 
 * ```409 Conflict``` - Indicates an error condition due to a conflict with the 
 current state of a resource, in the case of State API, Agent Profile or Activity Profile API
-calls, or in the Statement PUT call. See Section [6.3 Concurrency](#concurrency) for more details.
+calls, or in the Statement PUT or POST calls. See Section [6.3 Concurrency](#concurrency) for more details.
 
 * ```412 Precondition Failed``` - Indicates an error condition due to a failure of 
 a precondition posted with the request, in the case of State or Agent Profile or Activity Profile 


### PR DESCRIPTION
This PR
- addresses https://github.com/adlnet/xAPI-Spec/issues/333
- standardises the use of ',' and '-' to separate the list of what's being returned (now ',' is used throughout)
- where return values are different for GET vs PUT, POST and DELETE, split these over two lines. 
