### PR TITLE
Clarifications to timestamp

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -1411,7 +1411,7 @@ experience and the reception of the corresponding Statement by the LRS.
 
 Where the experience occurs over a period of time, the timestamp can represent the start, end or any point of time 
 during the experience. It is expected that communities of practice will define an appropriate point to record the 
-timestamp for difference experiences. For example when recording the experience of eating at a restaurant, it might 
+timestamp for different experiences. For example when recording the experience of eating at a restaurant, it might 
 be most appropriate to record the timestamp of the start of the experience; when recording the experience of 
 completing a qualification, it might be most appropriate to record the timestamp of the end of the experience.
 These examples are for illustrative purposes only and are not meant to be prescriptive.


### PR DESCRIPTION
Addresses https://github.com/adlnet/xAPI-Spec/issues/337 with a number of other amendments to the timestamp section. As it stands, this section is pretty unclear as to what the purpose of timestamp is and doesn't seem to allow for capturing past events for example as described by @brianjmiller here: http://tincanapi.com/2013/08/22/deep-dive-roundup/. The section also does not seem to match up to the description of the property in [4.1 Statement Properties](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI.md#41-statement-properties) which I take to be correct. 

I removed "Another cause is when Statements are propagated to other systems." because I didn't think it added much.

You'll notice that I've gone for the start of the experience rather than the end , against the consensus in https://github.com/adlnet/xAPI-Spec/issues/337. I got half way through the PR and switched back to start rather than end simply because practically speaking there will be many occasions when the end of the experience may be in the future. I also don't feel happy with the timestamp having a different meaning depending on whether or not we specify a duration. Using the start time is much cleaner, and a reporting tool can calculate the end time if a duration is specified. 

This one will need some discussion before merging. 
