### PR TITLE
Clarify that statement ID Is always required when putting a statement

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -2471,8 +2471,8 @@ Stores Statement with the given id.
 Returns: ```204 No Content```  
 
 <table>
-	<tr><th>Parameter</th><th>Type</th><th>Default</th><th>Description</th></tr>
-	<tr><td>statementId</td><td>String</td><td> </td><td>Id of Statement to record</td></tr>
+	<tr><th>Parameter</th><th>Type</th><th>Default</th><th>Required</th><th>Description</th></tr>
+	<tr><td>statementId</td><td>String</td><td> </td><td>Required</td><td>Id of Statement to record</td></tr>
 </table>
 
 ###### POST Statements


### PR DESCRIPTION
Addresses https://github.com/adlnet/xAPI-Spec/issues/364 and works towards https://github.com/adlnet/xAPI-Spec/issues/209

Note that I've set the value as "Required" rather than "yes", as I anticipate we'll be changing all the occurrences of "yes" in these columns to "Required" as part of https://github.com/adlnet/xAPI-Spec/issues/209 anyway. 
