### PR TITLE
Use Substatement instead of Sub-statement for objecttype

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -810,7 +810,7 @@ Some examples:
 
 Objects which are provided as a value for this field SHOULD include an "objectType" 
 field. If not specified, the objectType is assumed to be "Activity". Other valid values 
-are: <a href="#agentasobj">Agent</a>, <a href="#agentasobj">Group</a>, <a href="#substmt">Sub-Statement</a> or [StatementRef](#stmtref)</a>.
+are: <a href="#agentasobj">Agent</a>, <a href="#agentasobj">Group</a>, <a href="#substmt">SubStatement</a> or [StatementRef](#stmtref)</a>.
 The properties of an Object change according to the objectType.
 
 <a name="activity"/>


### PR DESCRIPTION
This is fixing a typo. The section on sub statements is very clear that the objecttype should be Substatement.
