### PR TITLE
Update xAPI.md

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -857,7 +857,7 @@ The table below lists the properties of the Activity Definition Object:
 	</tr>
 	<tr>
 		<td>description</td>
-		<td><a href="misclangmap">Language Map</a></td>
+		<td><a href="#misclangmap">Language Map</a></td>
 		<td>Recommended</td>
 		<td>A description of the Activity</td>
 	</tr>


### PR DESCRIPTION
Missing hash mark on Language Map link in Object section (4.1.4.1).
