### PR TITLE
Endpoint in example incorrectly included / on the end as well as capital S

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -3191,7 +3191,7 @@ function _ruuid() {
 
 ###### Method Path:  
 ```
-PUT : /xAPI/Statements/?statementId=ed1d064a-eba6-45ea-a3f6-34cdf6e1dfd9
+PUT : /xAPI/statements?statementId=ed1d064a-eba6-45ea-a3f6-34cdf6e1dfd9
 
 Body:
 {


### PR DESCRIPTION
Fixed to /statements instead of /Statements/
