### PR TITLE
fix misplaced stateId parameter

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -3123,7 +3123,7 @@ The Activity Profile API is much like the State API, allowing for arbitrary key
 
 ###### Details
 
-The semantics of the call are driven by the stateId parameter. If it is included, 
+The semantics of the call are driven by the activityId parameter. If it is included, 
 the GET method will act upon a single defined document identified by "profileId". 
 Otherwise, GET will return the available ids.
 
@@ -3206,7 +3206,7 @@ document pairs to be saved which are related to an Agent.
 
 ###### Details
 
-The semantics of the call are driven by the stateId parameter. If it is included, 
+The semantics of the call are driven by the agent parameter. If it is included, 
 the GET method will act upon a single defined document identified by "profileId". 
 Otherwise, GET will return the available ids.  
 


### PR DESCRIPTION
Actually, there is no `stateId` parameter in the Activity Profile API and in the Agent Profile API.

Though, I was not totally sure why the is also a `profileId` parameter besides the `activityId` and `agent` parameter. Is this `profileId` parameter needed in addition to the other parameter?
