### PR TITLE
Clarify intent of the `moreInfo` parameter

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -912,8 +912,8 @@ The table below lists the properties of the Activity Definition Object:
 	<tr>
 		<td>moreInfo</td>
 		<td>IRL</td>
-		<td>SHOULD resolve to a document human-readable information about the Activity,
-		which MAY include a way to 'launch' the Activity.
+		<td>SHOULD resolve to a document containing human-readable information about
+		the Activity, which MAY include a way to 'launch' the Activity.
 		</td>
 		<td>Optional</td>
 	</tr>


### PR DESCRIPTION
Adds missing verb in the Activity definition's `moreInfo` parameter to clarify the intent of the document.
