### PR TITLE
Bug fixes in examples

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -1002,7 +1002,7 @@ The table below lists the properties for Interaction Activities.
 		<td>String</td>
 		<td>As in "cmi.interactions.n.type" as defined in the SCORM 2004 4th 
 			Edition Run-Time Environment.</td>
-		<td>Required</td>
+		<td>Optional</td>
 	</tr>
 	<tr>
 		<td>correctResponsesPattern</td>


### PR DESCRIPTION
- Fixed Verb example in 4.1.3 …
  Was not a valid Verb, although it contained a valid Verb. Brought the Verb out to the root level of the object to parallel the structure of examples given elsewhere in the document.
- Fixed Context Activities example in 4.1.6.2 …
  Spaces are not allowed in an IRI. Fixed indenting.
