### PR TITLE
Tidy up IRIs definition

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -380,10 +380,14 @@ the same.
 
 <a name="def-iri" />
 
-__Internationalized Resource Identifier  (IRI)__: A unique identifier which may be an IRL. Used to identify an object 
-such as a verb, activity or activity type. 
-Unlike URIs, IRIs may contain some characters outside of the ASCII character set in order to support international languages.
-See [Wikipedia definition](http://en.wikipedia.org/wiki/Internationalized_resource_identifier).
+__Internationalized Resource Identifier  (IRI)__: A unique identifier which may be an IRL. 
+Used to identify an object such as a verb, activity or activity type. Unlike URIs, IRIs 
+can contain some characters outside of the ASCII character set in order to support international 
+languages. 
+
+IRIs always include a scheme. This is not a requirement of this standard, but part of the 
+definition of IRIs, per [RFC 3987](http://www.ietf.org/rfc/rfc3987.txt). What are sometimes 
+called 'relative IRIs' are not IRIs.
 
 <a name="def-irl" />
 
@@ -2180,7 +2184,6 @@ identifiers other than Activity id.
 * Metadata MAY be provided with an identifier.
 * If metadata is provided, both name and description SHOULD be included.
 * IRLs SHOULD be defined within a domain controlled by the person creating the IRL.
-* IRIs MUST always be full absolute IRIs including a scheme, and never Relative IRIs.
 * For any of the identifier IRIs above, if the IRI is an IRL created for use with this
 specification, the controller of that IRL SHOULD make this JSON metadata available at that 
 IRL when the IRL is requested and a Content-Type of "application/json" is requested.


### PR DESCRIPTION
Fixes #470 by moving the current content of the IRIs section to the requirements block of 5.4 and adding a new more definitiony definition in the definitions section. 
