### PR TITLE
Add clarity to use of verb metadata

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -775,7 +775,7 @@ The table below lists all properties of the Verb Object.
 * A system reading a Statement MUST use the Verb IRI to infer meaning.
 * The IRI contained in an id SHOULD contain a human-readable portion which SHOULD provide meaning enough 
 to disambiguate it from other similar(in syntax) Verbs.
-* A single Verb IRI MUST be be used to refer to multiple meanings.
+* A single Verb IRI MUST not be used to refer to multiple meanings.
 
 ###### Verb Display AP Requirements
 * The display property SHOULD be used by all Statements.

--- a/xAPI.md
+++ b/xAPI.md
@@ -770,16 +770,42 @@ The table below lists all properties of the Verb Object.
 	</tr>
 </table>
 
-###### Requirements
+###### Verb Id Requirements
 
-* The display property MUST be used to illustrate the meaning which is already determined by the Verb IRI.
 * A system reading a Statement MUST use the Verb IRI to infer meaning.
+* The IRI contained in an id SHOULD contain a human-readable portion which SHOULD provide meaning enough 
+to disambiguate it from other similar(in syntax) Verbs.
+* A single Verb IRI MUST be be used to refer to multiple meanings.
+
+###### Verb Display AP Requirements
+* The display property SHOULD be used by all Statements.
+* The display property MUST be used to illustrate the meaning which is already determined by the Verb IRI.
+
+###### Verb Display LRS Requirements
+The requirements below relate to the display property as returned by the LRS via the API.  
+
+* When queried for statements with a format of "exact", the LRS MUST return the Display property 
+exactly as included (or omitted) within the Statement.
+* When queried for statements with a format of "ids", the LRS SHOULD* NOT include the Display property.
+* When queried for statements with a format of "canonical", the LRS SHOULD return its canonical Display 
+for that Verb if it has one. 
+* The LRS may determine its canonical Display based on the Verb Display property included within 
+Statements it recieves, the name property included in the metadata as described in 
+[section 5.4 Identifier metadata](#miscmeta), or the Verb Display as defined in some other location.
+
+###### Verb Display Client Requirements
+The requirements below relate to the display property as displayed to a user either by the LRS or
+another system. 
+
 * The display property MUST NOT be used to alter the meaning of a Verb.
 * A system reading a Statement MUST NOT use the display property to infer any meaning from the Statement.
 * A system reading a Statement MUST NOT use the display property for any purpose other than display to a human.
 Using the display property for aggregation or categorization of Statements is an example of violating this requirement. 
-* The display property SHOULD be used by all Statements.
-* The IRI contained in the id SHOULD be human-readable and imply the Verb meaning.
+* Systems displaying a Statement's Verb in a user interface MAY choose to render the Verb Display property included within the 
+Statement, the name property included in the metadata as described in [section 5.4 Identifier metadata](#miscmeta), or the 
+Verb Display as defined in some other location.
+* Systems displaying a Statement's Verb MUST NOT display a word that differs from the meaning of the Verb but 
+MAY alter the wording and tense displayed for the purposes of human readability. 
 
 ###### Example
 This example shows a Verb with the recommended fields set.
@@ -804,9 +830,9 @@ _Semantics_
 
 The IRI represented by the Verb id identifies the particular semantics of a word, not the word itself. 
 
-For example, the English word "fired" could mean different things depending on context, such as "fired a 
-weapon", "fired a kiln", or "fired an employee". In this case, an IRI MUST identify one of these specific 
-meanings, not the word "fired". 
+For example, the English word "fired" could mean different things depending on context, such as 
+"fired(a weapon)", "fired(a kiln)", or "fired(an employee)". In this case, an IRI identifies one of 
+these specific meanings. 
 
 The display property has some flexibility in tense. While the Verb IRIs are expected to remain in the 
 past tense, if conjugating verbs to another tense (using the same Verb) within the Activity makes sense, 
@@ -2188,13 +2214,6 @@ IRL when the IRL is requested and a Content-Type of "application/json" is reques
 take the place of this metadata entirely if it was not provided or cannot be loaded. This MAY
 include metadata in other formats stored at the IRL of an identifier, particularly if that
 identifier was not coined for use with this specification.
-* The LRS MUST always return the Display property exactly as included (or omitted) within the Statement. 
-This requirement relates only to the LRS returning statements
-via the API, and not to the LRS displaying statements in a user interface. 
-* Systems displaying a statement's verb in a user interface MAY choose to render the verb display property included within the 
-statement, the name property included in the metadata as described above, or the verb display as defined in some other location.
-* Systems displaying a statement's verb MUST NOT display a word that differs from the meaning of the verb id but 
-MAY alter the wording and tense displayed for the purposes of human readability. 
 
 <a name="rtcom"/>
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -787,8 +787,8 @@ The requirements below relate to the display property as returned by the LRS via
 * When queried for statements with a format of "exact", the LRS MUST return the Display property 
 exactly as included (or omitted) within the Statement.
 * When queried for statements with a format of "ids", the LRS SHOULD* NOT include the Display property.
-* When queried for statements with a format of "canonical", the LRS SHOULD return its canonical Display 
-for that Verb if it has one. 
+* When queried for statements with a format of "canonical", the LRS SHOULD* return a canonical Display 
+for that Verb. 
 * The LRS may determine its canonical Display based on the Verb Display property included within 
 Statements it recieves, the name property included in the metadata as described in 
 [section 5.4 Identifier metadata](#miscmeta), or the Verb Display as defined in some other location.

--- a/xAPI.md
+++ b/xAPI.md
@@ -2188,13 +2188,13 @@ IRL when the IRL is requested and a Content-Type of "application/json" is reques
 take the place of this metadata entirely if it was not provided or cannot be loaded. This MAY
 include metadata in other formats stored at the IRL of an identifier, particularly if that
 identifier was not coined for use with this specification.
-* Systems displaying a statement's verb MAY choose to render the verb display property included within the 
-statement, the name property included in the metadata as described above, or the verb display as defined in some other location.
-* Systems displaying a statement's verb MUST NOT alter the meaning of the verb id but MAY alter the wording and tense displayed 
-for the purposes of human readability. 
 * The LRS MUST always return the display property exactly as included (or omitted) within the statement rather than using the
-name property defined within the metadata or some other source.
-
+name property defined within the metadata or some other source. This requirement relates only to the LRS returning statements
+via the API, and not to the LRS displaying statements in a user interface. 
+* Systems displaying a statement's verb in a user interface MAY choose to render the verb display property included within the 
+statement, the name property included in the metadata as described above, or the verb display as defined in some other location.
+* Systems displaying a statement's verb MUST NOT display a word that differs from the meaning of the verb id but 
+MAY alter the wording and tense displayed for the purposes of human readability. 
 
 <a name="rtcom"/>
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -755,8 +755,8 @@ The table below lists all properties of the Verb Object.
 		<td>id</td>
 		<td>IRI</td>
 		<td>Corresponds to a Verb definition. Each Verb definition 
-			corresponds to the meaning of a Verb, not the word. The IRI should 
-			be human-readable and contain the Verb meaning.</td>
+			corresponds to the meaning of a Verb, not the word. 
+		</td>
 		<td>Required</td>
 	</tr>
 	<tr>
@@ -774,7 +774,7 @@ The table below lists all properties of the Verb Object.
 
 * A system reading a Statement MUST use the Verb IRI to infer meaning.
 * The IRI contained in an id SHOULD contain a human-readable portion which SHOULD provide meaning enough 
-to disambiguate it from other similar(in syntax) Verbs.
+for a person reviewing the raw statement to disambiguate the Verb from other similar(in syntax) Verbs.
 * A single Verb IRI MUST NOT be used to refer to multiple meanings.
 
 ###### Verb Display AP Requirements

--- a/xAPI.md
+++ b/xAPI.md
@@ -775,7 +775,7 @@ The table below lists all properties of the Verb Object.
 * A system reading a Statement MUST use the Verb IRI to infer meaning.
 * The IRI contained in an id SHOULD contain a human-readable portion which SHOULD provide meaning enough 
 to disambiguate it from other similar(in syntax) Verbs.
-* A single Verb IRI MUST not be used to refer to multiple meanings.
+* A single Verb IRI MUST NOT be used to refer to multiple meanings.
 
 ###### Verb Display AP Requirements
 * The display property SHOULD be used by all Statements.

--- a/xAPI.md
+++ b/xAPI.md
@@ -778,34 +778,34 @@ for a person reviewing the raw statement to disambiguate the Verb from other sim
 * A single Verb IRI MUST NOT be used to refer to multiple meanings.
 
 ###### Verb Display AP Requirements
-* The display property SHOULD be used by all Statements.
-* The display property MUST be used to illustrate the meaning which is already determined by the Verb IRI.
+* The Display property SHOULD be used by all Statements.
+* The Display property MUST be used to illustrate the meaning which is already determined by the Verb IRI.
 
 ###### Verb Display LRS Requirements
-The requirements below relate to the display property as returned by the LRS via the API.  
+The requirements below relate to the Display property as returned by the LRS via the API.  
 
-* When queried for statements with a format of "exact", the LRS MUST return the Display property 
+* When queried for Statements with a Format of "exact", the LRS MUST return the Display property 
 exactly as included (or omitted) within the Statement.
-* When queried for statements with a format of "ids", the LRS SHOULD* NOT include the Display property.
-* When queried for statements with a format of "canonical", the LRS SHOULD* return a canonical Display 
+* When queried for Statements with a Format of "ids", the LRS SHOULD* NOT include the Display property.
+* When queried for Statements with a Format of "canonical", the LRS SHOULD* return a canonical Display 
 for that Verb. 
 * The LRS may determine its canonical Display based on the Verb Display property included within 
-Statements it recieves, the name property included in the metadata as described in 
+Statements it recieves, the Name property included in the metadata as described in 
 [section 5.4 Identifier metadata](#miscmeta), or the Verb Display as defined in some other location.
 
 ###### Verb Display Client Requirements
 The requirements below relate to the display property as displayed to a user either by the LRS or
 another system. 
 
-* The display property MUST NOT be used to alter the meaning of a Verb.
-* A system reading a Statement MUST NOT use the display property to infer any meaning from the Statement.
-* A system reading a Statement MUST NOT use the display property for any purpose other than display to a human.
-Using the display property for aggregation or categorization of Statements is an example of violating this requirement. 
+* The Display property MUST NOT be used to alter the meaning of a Verb.
+* A system reading a Statement MUST NOT use the Display property to infer any meaning from the Statement.
+* A system reading a Statement MUST NOT use the Display property for any purpose other than Display to a human.
+Using the Display property for aggregation or categorization of Statements is an example of violating this requirement. 
 * Systems displaying a Statement's Verb in a user interface MAY choose to render the Verb Display property included within the 
-Statement, the name property included in the metadata as described in [section 5.4 Identifier metadata](#miscmeta), or the 
+Statement, the Name property included in the metadata as described in [section 5.4 Identifier metadata](#miscmeta), or the 
 Verb Display as defined in some other location.
 * Systems displaying a Statement's Verb MUST NOT display a word that differs from the meaning of the Verb but 
-MAY alter the wording and tense displayed for the purposes of human readability. 
+MAY alter the wording and tense displayed for the purposes of human-readability. 
 
 ###### Example
 This example shows a Verb with the recommended fields set.
@@ -2185,7 +2185,7 @@ For supplying metadata about all other identifiers, see the format below:
 	<tr>
 		<td>name</td>
 		<td><a href="#misclangmap">Language Map</a></td>
-		<td>The human readable/visual name. For verbs, this is equivalent to the display property in a statement.</td>
+		<td>The human readable/visual name. For Verbs, this is equivalent to the Display property in a statement.</td>
 		<td>Optional</td>
 	</tr>
 	<tr>

--- a/xAPI.md
+++ b/xAPI.md
@@ -2159,7 +2159,7 @@ For supplying metadata about all other identifiers, see the format below:
 	<tr>
 		<td>name</td>
 		<td><a href="#misclangmap">Language Map</a></td>
-		<td>The human readable/visual name</td>
+		<td>The human readable/visual name. For verbs, this is equivelent to the display property in a statement.</td>
 		<td>Optional</td>
 	</tr>
 	<tr>
@@ -2188,6 +2188,12 @@ IRL when the IRL is requested and a Content-Type of "application/json" is reques
 take the place of this metadata entirely if it was not provided or cannot be loaded. This MAY
 include metadata in other formats stored at the IRL of an identifier, particularly if that
 identifier was not coined for use with this specification.
+* Systems displaying a statement's verb MAY choose to render the verb display property included within the 
+statement, the name property included in the metadata as described above, or the verb display as defined in some other location.
+* Systems displaying a statement's verb MUST NOT alter the meaning of the verb id but MAY alter the wording and tense displayed 
+for the purposes of human readability. 
+* The LRS MUST always return the display property exactly as included (or omitted) within the statement rather than using the
+name property defined within the metadata or some other source.
 
 
 <a name="rtcom"/>

--- a/xAPI.md
+++ b/xAPI.md
@@ -2188,8 +2188,8 @@ IRL when the IRL is requested and a Content-Type of "application/json" is reques
 take the place of this metadata entirely if it was not provided or cannot be loaded. This MAY
 include metadata in other formats stored at the IRL of an identifier, particularly if that
 identifier was not coined for use with this specification.
-* The LRS MUST always return the display property exactly as included (or omitted) within the statement rather than using the
-name property defined within the metadata or some other source. This requirement relates only to the LRS returning statements
+* The LRS MUST always return the Display property exactly as included (or omitted) within the Statement. 
+This requirement relates only to the LRS returning statements
 via the API, and not to the LRS displaying statements in a user interface. 
 * Systems displaying a statement's verb in a user interface MAY choose to render the verb display property included within the 
 statement, the name property included in the metadata as described above, or the verb display as defined in some other location.

--- a/xAPI.md
+++ b/xAPI.md
@@ -2159,7 +2159,7 @@ For supplying metadata about all other identifiers, see the format below:
 	<tr>
 		<td>name</td>
 		<td><a href="#misclangmap">Language Map</a></td>
-		<td>The human readable/visual name. For verbs, this is equivelent to the display property in a statement.</td>
+		<td>The human readable/visual name. For verbs, this is equivalent to the display property in a statement.</td>
 		<td>Optional</td>
 	</tr>
 	<tr>


### PR DESCRIPTION
We had a little debate here yesterday about verb metadata. This PR represents my personal view on what's implied as the way verb metadata can and must be handled. I see this as just clarifications, rather than new requirements, but I think that's open to debate.

Let's discuss!