### PR TITLE
Clarify ISO 8601 duration

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -1291,9 +1291,9 @@ The following table contains the properties of the Results Object.
 
 ###### Requirements
 
-* The Duration property SHOULD* be expressed using the ISO 8601 format for durations and SHOULD* NOT be expressed in the 
-format used for ISO 8601 time points. That is, the alternative format described in section 4.4.3.3 of ISO 8601 SHOULD* NOT
-be used. 
+* The Duration property MUST be expressed using the format for duration in ISO 8601:2004(E) section 4.4.3.2.
+The alternative format (in conformity with the format used for time points and described in ISO 8601:2004(E) 
+section 4.4.3.3) MUST NOT be used.
 
 <a name="Score"/>
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -1289,6 +1289,12 @@ The following table contains the properties of the Results Object.
 </tr>
 </table> 
 
+###### Requirements
+
+* The Duration property SHOULD* be expressed using the ISO 8601 format for durations and SHOULD* NOT be expressed in the 
+format used for ISO 8601 time points. That is, the alternative format described in section 4.4.3.3 of ISO 8601 SHOULD* NOT
+be used. 
+
 <a name="Score"/>
 
 ##### 4.1.5.1 Score


### PR DESCRIPTION
Fixes #477. 

Note that the consensus between @fugu13 and @nashyura in the issue was that this requirement should be a MUST. I disagree for the following reasons:

* Russell mentioned that Wax supports the alternate format and has users using it. This is going to be a breaking change for those users. 
* The alternative format is allowed under ISO 8601 so long as there is agreement between the communicating parties. On that basis, I don't see how an LRS can be non-conformant for receiving alternate format durations. It could be flagged as non-conformant for returning alternative format durations as presumably the test suite does not have prior agreement to accept that format. Equally, a test suite for content could brand content non-conformant for sending using that format. 

I've used SHOULD* instead. 