### PR TITLE
Clarification of Styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ If a specific data format and value are to be used, the <code> style should be u
 
 For example:
 
-A list of item ids is delimited by '''[,]'''.  The value returned must be '''false'''.
+A list of item ids is delimited by ```[,]```.  The value returned must be ```false```.
 
 ### Property and object names
 

--- a/README.md
+++ b/README.md
@@ -109,22 +109,48 @@ direct you to a page that gives you the ability to submit a request to the
 master repository to merge in the changes you committed.
 
 ##Style Guide
-### Property and object names
+### Expected Values
 
-When refering to a property or object, the name should be capitalized. No formatting or quotes should be used. 
+When a value is expected or described within plain text, but isn't specifically code, single quotes should be used.
+In situations where it is important to group text to be specific to the concept, single quotes should also be used.
+Single quotes are also allowable if the text would be unclear due to certain property names.
 
 For example:
 
-    The Context Activities property within the Context of the Statement is awesome.
+The reserved Verb 'http://adlnet.gov/expapi/verbs/voided' is an exception.
 
-Double quotes may be used when refering to properties within properties. When used within quotes, the capitalization of 
-should match that actually used in the object being described. 
+And
+
+These additional properties are called ‘interaction component lists’
+
+And
+
+The Score Object SHOULD include 'scaled'. or The 'binary' value should be used.
+
+If a specific data format and value are to be used, the <code> style should be used to denote this.
+
+For example:
+
+A list of item ids is delimited by <code>[,]</code>.  The value returned must be <code>false</code>.
+
+### Property and object names
+
+When refering to a property, parameter or object (but not calling it as that type, the name should be capitalized. 
+No formatting or quotes should be used. 
+
+For example:
+
+    Context Activities within the Context of the Statement are awesome.
+
+Double quotes should be used when refering to properties (also for objects and parameters) within properties or when the
+specific type is called out. When used within quotes, the capitalization of should match that actually used in the object
+being described. 
 
 For example:
 
     You can use "category" Context Activities to denote the recipe being followed in crafting the statement. 
 
-    The Group "member" property is an un-ordered list!
+    The "member" property is an un-ordered list!
 
 ### Headings
 Hashes (#) should be used for all headings following the following format:

--- a/README.md
+++ b/README.md
@@ -111,46 +111,55 @@ master repository to merge in the changes you committed.
 ##Style Guide
 ### Expected Values
 
-When a value is expected or described within plain text, but isn't specifically code, single quotes should be used.
-In situations where it is important to group text to be specific to the concept, single quotes should also be used.
-Single quotes are also allowable if the text would be unclear due to certain property names.
-
-For example:
-
-The reserved Verb 'http://adlnet.gov/expapi/verbs/voided' is an exception.
-
-And
-
-These additional properties are called ‘interaction component lists’
-
-And
-
-The Score Object SHOULD include 'scaled'. or The 'binary' value should be used.
-
 If a specific data format and value are to be used, the ```code``` style should be used to denote this.
 
 For example:
 
-A list of item ids is delimited by ```[,]```.  The value returned must be ```false```.
+    A list of item ids is delimited by ```[,]```
+
+And
+
+    The value returned must be ```false```.
 
 ### Property and object names
 
-When refering to a property, parameter or object (but not calling it as that type, the name should be capitalized. 
-No formatting or quotes should be used. 
+When refering to a property, parameter or object, but not specifically calling it out as property, parameter, or object 
+the name should be capitalized. No formatting or quotes should be used. 
 
 For example:
 
     Context Activities within the Context of the Statement are awesome.
 
-Double quotes should be used when refering to properties (also for objects and parameters) within properties or when the
-specific type is called out. When used within quotes, the capitalization of should match that actually used in the object
-being described. 
+When a specific type is called out, Double quotes should be used (e.g. properties, parameters, and objects). When used within quotes, the capitalization should match that actually used in the object being described. 
 
 For example:
 
     You can use "category" Context Activities to denote the recipe being followed in crafting the statement. 
 
+And
+
     The "member" property is an un-ordered list!
+
+When a value is expected or described within plain text, but isn't specifically code, single quotes should be used.
+In situations where it is important to group text to be specific to the concept, single quotes should also be used.
+Single quotes are also allowable if the text would be unclear due to certain property names.  Basically, single quotes
+are the catch-all for any case where not having any clarifying punctuation or style would cause confusion.
+
+For example:
+
+    The reserved Verb 'http://adlnet.gov/expapi/verbs/voided' is an exception.
+
+And
+
+    These additional properties are called ‘interaction component lists’
+
+And
+
+    The Score Object SHOULD include 'scaled'
+  
+And
+
+    The 'binary' value should be used.
 
 ### Headings
 Hashes (#) should be used for all headings following the following format:

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ And
 
 The Score Object SHOULD include 'scaled'. or The 'binary' value should be used.
 
-If a specific data format and value are to be used, the <code> style should be used to denote this.
+If a specific data format and value are to be used, the ```code``` style should be used to denote this.
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ If a specific data format and value are to be used, the <code> style should be u
 
 For example:
 
-A list of item ids is delimited by <code>[,]</code>.  The value returned must be <code>false</code>.
+A list of item ids is delimited by '''[,]'''.  The value returned must be '''false'''.
 
 ### Property and object names
 


### PR DESCRIPTION
Hey Everyone,

I've tried to be more specific on how we should use styles within the spec, specifically double quotes, single quotes, lack of quotes (i.e. just describing concepts), and code.  All opinions are welcome.  

I looked at our use of single quotes and here is the data I pulled:

Most uses of single quotes were as apostrophes or as quotes within quotes, which are acceptable.
The other uses were:
9 uses as a specific property or parameter (recommend double quotes)
2 uses as specific values which would be returned/used by code (recommend coding style)
10 uses as naming something or providing clarification that it is a concept in the document rather than simply the word (examples are 'Long', 'Short', and 'About')  These are correct uses.

I've earmarked these for a future PR and will do a more careful scan for the other uses as described in the guide in the near future.

