### PR TITLE
List headers and tidy whitespace in contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,17 +161,6 @@ And
 
     The 'binary' value should be used.
 
-Values of properties and parameters should be presented as code. ```<code></code>``` tags can be used for this
-purpose inside tables. 
-
-For example:
-
-    ```true```
-
-    <table><tr><td>
-        <code>true</code>
-    </td></tr></table>
-
 ### Headings
 Hashes (#) should be used for all headings following the following format:
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,17 @@ And
 
     The 'binary' value should be used.
 
+Values of properties and parameters should be presented as code. ```<code></code>``` tags can be used for this
+purpose inside tables. 
+
+For example:
+
+    ```true```
+
+    <table><tr><td>
+        <code>true</code>
+    </td></tr></table>
+
 ### Headings
 Hashes (#) should be used for all headings following the following format:
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -3309,8 +3309,14 @@ Statements are filtered.
 * Activity Objects contain Language Map Objects for name, description and interaction components. 
 The LRS MUST return only one language in each of these maps. 
 
-* Verb Objects contain Language Map Objects for Display. 
-The LRS SHOULD* return only one language in this map. 
+* The LRS MAY maintain canonical versions of language maps for any language map used in an object
+which has an id (objects without an id could never be matched to a canonical definition). 
+This includes the Verb Display property and some properties used within extensions. 
+
+* If the LRS maintains a canonical version of a language map, it SHOULD* return this when canonical 
+format is used. 
+
+* The LRS SHOULD* return only one language within each language map for which it returns a canonical map. 
 
 * In order to choose the most relevant language, the LRS MUST apply the Accept-Language header as 
 described in <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html"> RFC 2616</a> 

--- a/xAPI.md
+++ b/xAPI.md
@@ -1222,6 +1222,19 @@ Run-Time Environment. See [Appendix C](#AppendixC) for examples of each format.
 	</tr>
 </table>
 
+Note that the Correct Response Pattern contains an array of response patterns. A learner's response will be considered correct if it matches
+**any** of the response patterns in that array. Where a response pattern is a delimited list, the learner's response is only considered correct
+if **all** of the items in that list match the learner's response. For example, consider the Correct Response Pattern with a value of:
+
+```
+"correctResponsesPattern": [
+    "foo[,]bar",
+    "foo"
+]
+``` 
+
+In this example, ```foo[,]bar``` and  ```foo``` are correct learner responses; ```bar``` is not.
+
 ###### Characterstring parameters
 Some of the values within the responses described above can be prepended with certain additional parameters. These were originally based on the characterstring
 delimiters defined in the SCORM 2004 4th Edition Run-Time Environment. These parameters are represented by the format ```{parameter=value}```.

--- a/xAPI.md
+++ b/xAPI.md
@@ -3005,7 +3005,7 @@ do not match.
 
 * Activity Providers SHOULD use POST instead of PUT. 
 * When PUTing statements, the Id property of the Statement SHOULD* be used. 
-* Where provided, the Id property of the Statement MUST match the 'statementId' parameter of the request. 
+* Where provided, the Id property of the Statement MUST match the "statementId" parameter of the request. 
 
 
 <a name="stmtapipost"/>

--- a/xAPI.md
+++ b/xAPI.md
@@ -3310,8 +3310,12 @@ include attachment raw data and MUST report application/json.
 
 ###### Filter Conditions for StatementRefs 
 
-For filter parameters which are not time or sequence based (that is, other than
-since, until, or limit), Statements which target another Statement (by using a StatementRef
+This section outlines rules by which additional Statements are considered to meet the filter coniditions even
+if they do not match the original query's filter parameters but instead target a Statement which does. 
+These rules **do not** apply when using filter parameters which are time or sequence based (that is, other 
+than since, until, or limit), and when retrieving a single Statement with statementId or voidedStatementId.
+
+Statements which target another Statement (by using a StatementRef
 as the Object of the Statement) will meet the filter condition if the targeted Statement meets 
 the condition. The time and sequence based parameters MUST still be applied to the Statement 
 making the StatementRef in this manner. This rule applies recursively, so that "Statement a" is a 
@@ -3324,8 +3328,6 @@ Statement will not mention "Ben" or "explosives training", but when fetching Sta
 with an Actor filter of "Ben" or an Activity filter of "explosives training", both
 Statements match and will be returned so long as they fall into the time or sequence
 being fetched.
-
-This section does not apply when retrieving Statements with statementId or voidedStatementId.
 
 __Note:__StatementRefs used as a value of the Statement property within Context do not affect how
 Statements are filtered.
@@ -3358,11 +3360,12 @@ which language entry to include, rather than to the resource (list of Statements
 ###### Requirements
 
 * The LRS MUST not return any Statement which has been voided, unless that Statement has been
-requested by voidedStatementId. 
+requested by voidedStatementId. The process described in
+[the section on filter conditions for StatementRefs](#queryStatementRef) is no exception to this
+requirement.
 
 * The LRS MUST still return any Statements targeting the voided 
-Statement when retrieving Statements using explicit or implicit time or sequence based retrieval,
-unless they themselves have been voided, as described in
+Statement, following the process and conditions described in
 [the section on filter conditions for StatementRefs](#queryStatementRef). This includes the
 voiding Statement, which cannot be voided. Reporting tools can identify the presence and
 statementId of any voided Statements by the target of the voiding Statement. 

--- a/xAPI.md
+++ b/xAPI.md
@@ -2545,10 +2545,9 @@ overwrite or remove existing data, being:
 * Agent Profile API 
 * Activity Profile API
 
+##### Client Requirements
 The State API will permit PUT, POST and DELETE requests without concurrency headers, since state conflicts
 are unlikely. The requirements below only apply to Agent Profile API and Activity Profile API.
-
-##### Client Requirements
 
 * A Client making a PUT request to either the Agent Profile API or Activity Profile API MUST include the 
 [If-Match](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.24) header or the 

--- a/xAPI.md
+++ b/xAPI.md
@@ -1,7 +1,7 @@
 # Experience API
 ## Advanced Distributed Learning (ADL) Co-Laboratories
 
->"Copyright 201 Advanced Distributed Learning (ADL) Initiative, U.S. Department of Defense
+>"Copyright 2013 Advanced Distributed Learning (ADL) Initiative, U.S. Department of Defense
 
 >Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except 
 >in compliance with the License. You may obtain a copy of the License at
@@ -306,7 +306,6 @@ be unintuitive and/or lengthy to dissect into a list of requirements.
 * [Authorization](#def-authorization)
 * [Base Endpoint](#def-baseendpoint)
 * [Community of Practice](#def-community-of-practice)
-* [Controlled Vocabulary](#def-controlled-vocabulary)
 * [Experience API (xAPI)](#def-experience-api)
 * [Immutable](#def-immutable)
 * [Internationalized Resource Identifier (IRI)](#def-iri)
@@ -369,14 +368,6 @@ Activity Provider, reporting tool, an LMS, or another LRS.
 
 __Community of Practice__: A group, usually connected by a common cause, role or 
 purpose, which operates in a common modality.
-
-<a name="def-community-profile" />
-
-__Community Profile__: A unique collection of artifacts such as CoP use cases, controlled vocabulary terms, implementation instructions, and pre-defined examples (e.g., recipes) of how to capture specific types of learning activities using xAPI. 
-
-<a name="def-controlled-vocabulary" />
-
-__Controlled Vocabulary__: A restricted, agreed-on list of words or terms developed by a CoP. The objective of a controlled vocabulary is to achieve consistency in the semantic description, storage, and retrieval of xAPI data. It is controlled because terms from the list are intended to be used for a specific subject area or domain of knowledge. There should also be control over how the list is maintained. The vocabualry list could grow, but only under defined policies by a CoP.
 
 <a name="def-experience-api" />
 
@@ -452,8 +443,8 @@ these recommendations will become MUST requirements in a future version.
 
 <a name="def-profile" />
 
-__Profile__: A construct where information about the agent or activity is kept, 
-typically in name/document pairs that may provide meaning for an application.
+__Profile__: A construct where information about the learner or activity is kept, 
+typically in name/document pairs that have meaning to an instructional system component.
 
 <a name="def-registration" />
 
@@ -483,7 +474,7 @@ informal references to the Experience API.
 
 <a name="def-verb" />
 
-__Verb__: Defines the action performed by the Actor on an Activity within a Statement. 
+__Verb__: Defines the action being done by the Actor within the Activity within a Statement. 
 
 <a name="statement"/> 
 
@@ -900,7 +891,8 @@ or the Verb IRI http://example.com/فعل/خواندن might denote the action o
 
 Communities of practice will, at some point in time, need to establish new Verbs to meet the needs of their constituency.
 
-Therefore, it is expected that xAPI communities of practice generate <a href="#def-community-profile">community profiles</a> based on both new and existing <a href="#controlled-vocabulary">controlled vocabularies</a>. 
+Therefore, it is expected that xAPI communities of practice generate profiles, lists, and repositories that become 
+centered on Verb vocabularies.  ADL is creating a companion document containing Verbs for xAPI to serve the ADL Community.
 
 In fulfillment of the requirements below, a collection of IRIs of recommended Verbs exists.  There are times when 
 Activity Providers might wish to use a different Verb for the same meaning.
@@ -1579,7 +1571,8 @@ outside the scope of this specification.
 ###### Requirements
 
 * The Score Object SHOULD include 'scaled' if a logical percent based score is known.
-* The Score Object SHOULD NOT be used for scores relating to progress or completion.  Consider using an <a href="https://github.com/adlnet/xAPI-Spec/blob/master/xAPI.md#miscext">extension</a> instead.
+* The Score Object SHOULD NOT be used for scores relating to progress or completion.  Consider using an extension
+from an extension profile instead.
 
 
 <a name="context"/>
@@ -1716,7 +1709,7 @@ the qualification relates to the class as the grouping.
 
 3. __Category__: an Activity used to categorize the Statement.
 "Tags" would be a synonym. Category SHOULD be used to indicate
-a <a href="#def-community-profile">community profile</a> of xAPI behaviors, as well as other categorizations.
+a "profile" of xAPI behaviors, as well as other categorizations.
 For example: Anna attempts a biology exam, and the Statement is
 tracked using the CMI-5 profile. The Statement's Activity refers
 to the exam, and the category is the CMI-5 profile.

--- a/xAPI.md
+++ b/xAPI.md
@@ -1987,8 +1987,8 @@ results when the attachments filter is false.
     * MUST include a Content-Transfer-Encoding parameter with a value of "binary" in each part's header after the first (statements) part.
     * SHOULD only include one copy of an attachment's data when the same attachment is used in multiple Statements that are sent together.
     * SHOULD include a Content-Type parameter in each part's header. For the first part (containing the statement) this MUST be "application/json".
-    * Where parameters have a corresponding property within the Attachment Object (outlined in the table above), the value of these parameters and properties
-    for each Attachment MUST match. 
+   	* Where parameters have a corresponding property within the Attachment Object (outlined in the table above), and both the parameter and 
+   	property are specified for a given Attachment, the value of these parameters and properties MUST match. 
 
 
 ###### LRS Requirements

--- a/xAPI.md
+++ b/xAPI.md
@@ -1534,7 +1534,7 @@ The table below defines the Score Object.
 	</tr>
 </table>
 
-The properties of the score object were originally based on the corresponding properties of cmi.score as defined in SCORM 2004 
+The properties of the score object are based on the corresponding properties of cmi.score as defined in SCORM 2004 
 4th Edition. 
 
 ###### Requirements

--- a/xAPI.md
+++ b/xAPI.md
@@ -3177,27 +3177,27 @@ Returns: ```200 OK```, Statement or [Statement Result](#retstmts) (See [Section 
 	</tr>
 	<tr>
 		<td>format</td>
-		<td>String: ("ids", "exact", or "canonical")</td>
+		<td>String: (```ids```, ```exact```, or ```canonical```)</td>
 		<td>exact</td>
-		<td>If "ids", only include minimum information necessary in Agent, Activity, Verb 
+		<td>If ```ids```, only include minimum information necessary in Agent, Activity, Verb 
 			and Group Objects to identify them. For anonymous groups this means including 
 			the minimum information needed to identify each member. 
 			<br/><br/>
-			If "exact", return Agent, Activity, Verb and Group Objects populated exactly as they 
+			If ```exact```, return Agent, Activity, Verb and Group Objects populated exactly as they 
 			were when the Statement was received. An LRS requesting Statements for the purpose 
-			of importing them would use a format of "exact".  
+			of importing them would use a format of ```exact```.  
 			<br/><br/>
-			If "canonical", return Activity Objects and Verbs populated with the canonical
+			If ```canonical```, return Activity Objects and Verbs populated with the canonical
 			definition of the Activity Objects and Display of the Verbs as determined by the LRS, after
 			applying the <a href="#queryLangFiltering">language filtering process defined below</a>,
-			and return the original Agent and Group Objects as in "exact" mode.  
+			and return the original Agent and Group Objects as in ```exact``` mode.  
 		</td>
 		<td>Optional</td>
 	</tr>
 	<tr>
-		<td>attachments</td><td>Boolean</td><td>False</td>
-		<td>If true, the LRS uses the multipart response format and includes all attachments as 
-		described previously.  If false, the LRS sends the prescribed response with Content-Type 
+		<td>attachments</td><td>Boolean</td><td>false</td>
+		<td>If ```true```, the LRS uses the multipart response format and includes all attachments as 
+		described previously.  If ```false```, the LRS sends the prescribed response with Content-Type 
 		application/json and cannot use attachments.</td>
 		<td>Optional</td>
 	</tr>
@@ -3205,10 +3205,12 @@ Returns: ```200 OK```, Statement or [Statement Result](#retstmts) (See [Section 
 		<td>ascending</td>
 		<td>Boolean</td>
 		<td>false</td>
-		<td>If true, return results in ascending order of stored time</td>
+		<td>If ```true```, return results in ascending order of stored time</td>
 		<td>Optional</td>
 	</tr>
 </table>
+
+__Note:__The values of Boolean parameters are represented as ```true``` or ```false``` as in JSON. 
 
 ###### Requirements
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -3311,9 +3311,10 @@ include attachment raw data and MUST report application/json.
 
 This section outlines rules by which Statements targeting other Statements can sometimes be considered to 
 meet the filter conditions of a query even if they do not match the original query's filter parameters. 
-These rules **do not** apply when retrieving a single Statement with statementId or voidedStatementId.
+These rules **do not** apply when retrieving a single Statement using "statementId" or "voidedStatementId" query 
+parameters.
 
-For filter parameters which are not time or sequence based (that is, other than since, until, or limit), 
+For filter parameters which are not time or sequence based (that is, other than "since", "until", or "limit"), 
 Statements which target another Statement (by using a StatementRef
 as the Object of the Statement) will meet the filter condition if the targeted Statement meets 
 the filter condition.

--- a/xAPI.md
+++ b/xAPI.md
@@ -2036,6 +2036,21 @@ contain attachments.
 * The Client MAY send batches of type "application/json" where every attachment
 Object has a fileUrl, ignoring all requirements based on the "multipart/mixed" format.
 
+###### File URL
+The File URL is intended to provide a location from which the LRS or another system can retrieve the
+attachment. There are, however, no requirements for the owner of the attachment to make the 
+attachment data available at the location indefinately or to make the attachment publically
+available without security restrictions. When determining attachment hosting arrangements, 
+designers of systems that will send Statements using the "fileUrl" property are encouraged to 
+consider the needs of end recipient(s) of the Statement especially if the attachment content 
+is not included with the Statement.
+
+* The attachment data SHOULD be retirevable at the IRL indicated by the fileUrl.
+* The file host MAY stop providing the attachment data at this IRL at any time. 
+* Security restrictions MAY be applied to clients attempting to access the attachment data at this IRL. 
+
+The duration an attachment is made available for, and the security restrictions applied to
+hosted attachments, are out of scope of this specification. 
 
 ###### Example
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -3534,12 +3534,12 @@ Returns (GET): ```200 OK```, State Content
 ###### Multiple Document GET
 Example endpoint: http://example.com/xAPI/activities/state
 
-Fetches ids of all state data for this context (Activity + Agent \[ + 
+Fetches State Ids of all state data for this context (Activity + Agent \[ + 
 registration if specified\]). If "since" parameter is specified, this 
 is limited to entries that have been stored or updated since the specified 
 timestamp (exclusive).  
 
-Returns: ```200 OK```, Array of ids  
+Returns: ```200 OK```, Array of 'stateId' values.  
 <table>
 	<tr><th>Parameter</th><th>Type</th><th>Description</th><th>Required</th></tr>
 	<tr>
@@ -3660,11 +3660,11 @@ Returns (GET): ```200 OK```, Profile Content
 ###### Multiple Document GET
 Example endpoint: http://example.com/xAPI/activities/profile
 
-Loads ids of all profile entries for an Activity. If "since" parameter is 
+Fetches Profile Ids of all profile entries for an Activity. If "since" parameter is 
 specified, this is limited to entries that have been stored or updated since 
 the specified timestamp (exclusive).  
 
-Returns: ```200 OK```, List of ids  
+Returns: ```200 OK```, Array of 'profileId' values. 
 <table>
 	<tr><th>Parameter</th><th>Type</th><th>Description</th><th>Required</th><tr>
 	<tr>
@@ -3817,14 +3817,14 @@ Returns (GET): ```200 OK```, Profile Content
 	</tr>
 </table>  
 
-###### Multiple Agent or Profile GET 
+###### Multiple Document GET 
 Example endpoint: http://example.com/xAPI/agents/profile
 
-Loads ids of all profile entries for an Agent. If "since" parameter is specified, 
+Fetches Profile Ids of all profile entries for an Agent. If "since" parameter is specified, 
 this is limited to entries that have been stored or updated since the specified 
 timestamp (exclusive).  
 
-Returns: ```200 OK```, List of ids  
+Returns: ```200 OK```, Array of 'profileId' values.   
 <table>
 	<tr><th>Parameter</th><th>Type</th><th>Description</th><th>Required</th></tr>
 	<tr>

--- a/xAPI.md
+++ b/xAPI.md
@@ -3310,12 +3310,14 @@ include attachment raw data and MUST report application/json.
 
 This section outlines rules by which additional Statements are considered to meet the filter coniditions even
 if they do not match the original query's filter parameters but instead target a Statement which does. 
-These rules **do not** apply when using filter parameters which are time or sequence based (that is, other 
-than since, until, or limit), and when retrieving a single Statement with statementId or voidedStatementId.
+These rules **do not** apply when retrieving a single Statement with statementId or voidedStatementId.
 
+For filter parameters which are not time or sequence based (that is, other than since, until, or limit), 
 Statements which target another Statement (by using a StatementRef
 as the Object of the Statement) will meet the filter condition if the targeted Statement meets 
-the condition. The time and sequence based parameters MUST still be applied to the Statement 
+the condition of that filter parameter.
+
+The time and sequence based parameters MUST still be applied to the Statement 
 making the StatementRef in this manner. This rule applies recursively, so that "Statement a" is a 
 match when a targets b which targets c and the filter conditions described above match for 
 "Statement c".

--- a/xAPI.md
+++ b/xAPI.md
@@ -3004,8 +3004,8 @@ do not match.
 ###### Activity Provider Requirements
 
 * Activity Providers SHOULD use POST instead of PUT. 
-* When PUTing statements, the Id property of the Statement SHOULD* be used. 
-* Where provided, the Id property of the Statement MUST match the "statementId" parameter of the request. 
+* When PUTing statements, the "id" property of the Statement SHOULD* be used. 
+* Where provided, the "id" property of the Statement MUST match the "statementId" parameter of the request. 
 
 
 <a name="stmtapipost"/>

--- a/xAPI.md
+++ b/xAPI.md
@@ -702,14 +702,13 @@ or store and retrieve documents relating to a group.
 
 ##### 4.1.2.3 Inverse Functional Identifier
 ###### Description 
-An "Inverse Functional Identifier" is a value of an Agent or Identified
+An Inverse Functional Identifier (IFI) is a value of an Agent or Identified
 Group that is guaranteed to only ever refer to that Agent or Identified Group.
 
 ###### Rationale
-Learning experiences become meaningless if they cannot be attributed to identifiable
-individuals and/or groups. In an xAPI Statement this is accomplished with a set of
-Inverse Functional Identifiers loosely inspired on the widely accepted FOAF principle
-(see: <a href="http://xmlns.com/foaf/spec/#term_Agent"> Friend Of A Friend</a>).
+Agents and Groups need to be uniquely identifiable in order for data to be stored and retrieved against them. 
+In an xAPI Statement this is accomplished using Inverse Functional Identifiers which are loosely inspired 
+on the widely accepted FOAF principle (see: <a href="http://xmlns.com/foaf/spec/#term_Agent"> Friend Of A Friend</a>).
 
 ###### Details
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -1564,7 +1564,7 @@ The table below defines the Score Object.
 </table>
 
 The properties of the score object are based on the corresponding properties of cmi.score as defined in SCORM 2004 
-4th Edition. If both scaled and raw score are provided, the exact relationship between the scaled and raw score is determined 
+4th Edition. If both "scaled" and "raw" properties are provided, the exact relationship between their two values is determined 
 by the Activity Provider or their Community of Practice; scaling and normalization are out of scope of this specification.
 
 ###### Requirements

--- a/xAPI.md
+++ b/xAPI.md
@@ -2962,7 +2962,7 @@ The basic communication mechanism of the Experience API.
 
 Example endpoint: ```http://example.com/xAPI/statements```
 
-Stores Statement with the given id.
+Stores a single Statement with the given id. POST can also be used to store single Statements.
 
 Returns: ```204 No Content```  
 
@@ -2972,7 +2972,7 @@ Returns: ```204 No Content```
 	<td>Id of Statement to record</td></td><td>Required</td></tr>
 </table>
 
-###### Requirements
+###### LRS Requirements
 
 * An LRS MUST NOT make any modifications to its state based on receiving a Statement
 with a statementID that it already has a Statement for. Whether it responds with
@@ -2985,6 +2985,13 @@ do not match.
 
 * The LRS MAY respond before Statements that have been stored are available for retrieval.
 
+###### Activity Provider Requirements
+
+* Activity Providers SHOULD use POST instead of PUT. 
+* When PUTing statements, the Id property of the Statement SHOULD* be used. 
+* Where provided, the Id property of the Statement MUST match the 'statementId' parameter of the request. 
+
+
 <a name="stmtapipost"/>
 
 ####7.3.2 POST Statements
@@ -2993,9 +3000,9 @@ do not match.
 
 Example endpoint: ```http://example.com/xAPI/statements```
 
-Stores a Statement, or a set of Statements. Since the PUT method targets a specific 
-Statement id, POST is used rather than PUT to save multiple Statements, or to 
-save one Statement without first generating a Statement id. An alternative for systems 
+Stores a Statement, or a set of Statements. 
+
+An alternative for systems 
 that generate a large amount of Statements is to provide the LRS side of the API 
 on the AP, and have the LRS query that API for the list of updated (or new) 
 Statements periodically. This will likely only be a realistic option for systems 

--- a/xAPI.md
+++ b/xAPI.md
@@ -1983,7 +1983,7 @@ results when the attachments filter is false.
     * MUST include an X-Experience-API-Hash parameter in each part's header after the first (Statements) part.
     * MUST include a Content-Transfer-Encoding parameter with a value of "binary" in each part's header after the first (statements) part.
     * SHOULD only include one copy of an attachment's data when the same attachment is used in multiple Statements that are sent together.
-    * SHOULD include a Content-Type parameter in each part's header, for the first part (containing the statement) this MUST be "application/json".
+    * SHOULD include a Content-Type parameter in each part's header. For the first part (containing the statement) this MUST be "application/json".
     * Where parameters have a corresponding property within the Attachment Object (outlined in the table above), the value of these parameters and properties
     for each Attachment MUST match. 
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -3347,12 +3347,12 @@ Statements are filtered.
 * Activity Objects contain Language Map Objects for name, description and interaction components. 
 The LRS MUST return only one language in each of these maps. 
 
-* The LRS MAY maintain canonical versions of language maps for any language map used in an object
-which has an id (objects without an id could never be matched to a canonical definition). 
-This includes the Verb Display property and any language maps used within extensions. 
+* The LRS MAY maintain canonical versions of language maps against any IRI identifying an object containing
+language maps. This includes the language map stored in the Verb Display property and potentially some 
+language maps used within extensions. 
 
-* If the LRS maintains a canonical version of a language map, it SHOULD* return this when canonical 
-format is used. 
+* If the LRS maintains a canonical version of a language map, it SHOULD* return this cannonical langauge map
+ when canonical format is used to retrieve Statements. 
 
 * The LRS SHOULD* return only one language within each language map for which it returns a canonical map. 
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -2470,12 +2470,12 @@ Using Semantic Versioning will allow Clients and LRSs to reliably know compatibi
 ###### Details
 
 Starting with 1.0.0, xAPI will be versioned according to [Semantic Versioning 1.0.0](http://semver.org/spec/v1.0.0.html).  Every request from a Client and every response from the LRS includes an HTTP header with the name 
-“X-Experience-API-Version" and the version as the value. For example, ``X-Experience-API-Version : 1.0.1``
+“X-Experience-API-Version" and the version as the value. For example, ``X-Experience-API-Version : 1.0.3``
 
 ###### LRS Requirements
 
 * The LRS MUST include the "X-Experience-API-Version" header in every response.
-* The LRS MUST set this header to "1.0.1".
+* The LRS MUST set this header to "1.0.3".
 * The LRS MUST accept requests with a version header of "1.0" as if the version header was "1.0.0".
 * The LRS MUST reject requests with version header prior to "1.0.0" unless such requests are routed to a 
 fully conformant implementation of the prior version specified in the header.
@@ -2486,7 +2486,7 @@ of the problem.
 ###### Client Requirements
 
 * The Client MUST include the "X-Experience-API-Version" header in every request.
-* The Client MUST set this header to "1.0.1".
+* The Client MUST set this header to "1.0.3".
 * The Client SHOULD tolerate receiving responses with a version of "1.0.0" or later.
 * The Client SHOULD tolerate receiving data structures with additional properties.
 * The Client SHOULD ignore any properties not defined in version 1.0.0 of the spec.
@@ -4963,7 +4963,7 @@ Request Headers:
     Accept-Language:en-US,en;q=0.8
     Authorization: Basic VGVzdFVzZXI6cGFzc3dvcmQ=
     Content-Type: application/json
-    X-Experience-API-Version: 1.0.1
+    X-Experience-API-Version: 1.0.3
     Content-Length: 351
 
 Content:
@@ -4987,7 +4987,7 @@ Request Headers:
 Content (with added line breaks and not URL encoded for readability):
     statementId=c70c2b85-c294-464f-baca-cebd4fb9b348
     &Authorization=Basic VGVzdFVzZXI6cGFzc3dvcmQ=
-    &X-Experience-API-Version=1.0.1
+    &X-Experience-API-Version=1.0.3
     &Content-Type=application/json
     &Content-Length=351
     &content={"id":"c70c2b85-c294-464f-baca-cebd4fb9b348","timestamp":"2014-12-29T12:09:37.468Z","actor":{"objectType":"Agent","mbox":"mailto:example@example.com","name":"Test User"},"verb":{"id":"http://adlnet.gov/expapi/verbs/experienced","display":{"en-US":"experienced"}},"object":{"id":"http://example.com/xAPI/activities/myactivity","objectType":"Activity"}}

--- a/xAPI.md
+++ b/xAPI.md
@@ -2787,7 +2787,14 @@ track learning records.
 
 __Note:__ In all of the example endpoints given in the specification, 
 "http://example.com/xAPI/" is the example base endpoint of the LRS. All other IRI 
-syntax after this represents the particular endpoint used.
+syntax after this represents the particular endpoint used. A full list of endpoints
+is included in [Appendix F: Table of All Endpoints](#AppendixF).
+
+###### Requirements
+
+* The LRS MUST support all of the endpoints described in [this section](#datatransfer). (__Note:__ This requirement *does not* apply to 
+the OAuth endpoints described in [Section 6.4.2 OAuth Authorization Scope](#oauthscope); see that section for requirements relating to
+the OAuth endpoints.) 
 
 <a name="errorcodes" /> 
 
@@ -4877,6 +4884,7 @@ attachment message format.
 
 ## Appendix F: Table of All Endpoints
 
+### Required Endpoints
 <table>
 	<tr>
 		<th>Endpoint (Base Endpoint of the LRS Precedes Each Endpoint)</th>
@@ -4909,6 +4917,14 @@ attachment message format.
 	<tr>
 		<td>about</td>
 		<td>LRS Information</td>
+	</tr>
+</table>
+
+### OAuth Endpoints
+<table>
+	<tr>
+		<th>Endpoint (Base Endpoint of the LRS Precedes Each Endpoint)</th>
+		<th>Function</th>
 	</tr>
 	<tr>
 		<td>OAuth/initiate</td>

--- a/xAPI.md
+++ b/xAPI.md
@@ -3315,6 +3315,10 @@ meet the filter conditions of a query even if they do not match the original que
 These rules **do not** apply when retrieving a single Statement using "statementId" or "voidedStatementId" query 
 parameters.
 
+'Targeting Statements' means that one Statement (the targeting Statement) includes the Statement Id of another
+Statement (the targeted Statement) as a Statemnent Reference either as the object of the Statement or within the 
+"statement" property of the Context. 
+
 For filter parameters which are not time or sequence based (that is, other than "since", "until", or "limit"), 
 Statements which target another Statement (by using a StatementRef
 as the Object of the Statement) will meet the filter condition if the targeted Statement meets 

--- a/xAPI.md
+++ b/xAPI.md
@@ -1,7 +1,7 @@
 # Experience API
 ## Advanced Distributed Learning (ADL) Co-Laboratories
 
->"Copyright 2013 Advanced Distributed Learning (ADL) Initiative, U.S. Department of Defense
+>"Copyright 201 Advanced Distributed Learning (ADL) Initiative, U.S. Department of Defense
 
 >Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except 
 >in compliance with the License. You may obtain a copy of the License at
@@ -306,6 +306,7 @@ be unintuitive and/or lengthy to dissect into a list of requirements.
 * [Authorization](#def-authorization)
 * [Base Endpoint](#def-baseendpoint)
 * [Community of Practice](#def-community-of-practice)
+* [Controlled Vocabulary](#def-controlled-vocabulary)
 * [Experience API (xAPI)](#def-experience-api)
 * [Immutable](#def-immutable)
 * [Internationalized Resource Identifier (IRI)](#def-iri)
@@ -368,6 +369,14 @@ Activity Provider, reporting tool, an LMS, or another LRS.
 
 __Community of Practice__: A group, usually connected by a common cause, role or 
 purpose, which operates in a common modality.
+
+<a name="def-community-profile" />
+
+__Community Profile__: A unique collection of artifacts such as CoP use cases, controlled vocabulary terms, implementation instructions, and pre-defined examples (e.g., recipes) of how to capture specific types of learning activities using xAPI. 
+
+<a name="def-controlled-vocabulary" />
+
+__Controlled Vocabulary__: A restricted, agreed-on list of words or terms developed by a CoP. The objective of a controlled vocabulary is to achieve consistency in the semantic description, storage, and retrieval of xAPI data. It is controlled because terms from the list are intended to be used for a specific subject area or domain of knowledge. There should also be control over how the list is maintained. The vocabualry list could grow, but only under defined policies by a CoP.
 
 <a name="def-experience-api" />
 
@@ -443,8 +452,8 @@ these recommendations will become MUST requirements in a future version.
 
 <a name="def-profile" />
 
-__Profile__: A construct where information about the learner or activity is kept, 
-typically in name/document pairs that have meaning to an instructional system component.
+__Profile__: A construct where information about the agent or activity is kept, 
+typically in name/document pairs that may provide meaning for an application.
 
 <a name="def-registration" />
 
@@ -474,7 +483,7 @@ informal references to the Experience API.
 
 <a name="def-verb" />
 
-__Verb__: Defines the action being done by the Actor within the Activity within a Statement. 
+__Verb__: Defines the action performed by the Actor on an Activity within a Statement. 
 
 <a name="statement"/> 
 
@@ -891,8 +900,7 @@ or the Verb IRI http://example.com/فعل/خواندن might denote the action o
 
 Communities of practice will, at some point in time, need to establish new Verbs to meet the needs of their constituency.
 
-Therefore, it is expected that xAPI communities of practice generate profiles, lists, and repositories that become 
-centered on Verb vocabularies.  ADL is creating a companion document containing Verbs for xAPI to serve the ADL Community.
+Therefore, it is expected that xAPI communities of practice generate <a href="#def-community-profile">community profiles</a> based on both new and existing <a href="#controlled-vocabulary">controlled vocabularies</a>. 
 
 In fulfillment of the requirements below, a collection of IRIs of recommended Verbs exists.  There are times when 
 Activity Providers might wish to use a different Verb for the same meaning.
@@ -1571,8 +1579,7 @@ outside the scope of this specification.
 ###### Requirements
 
 * The Score Object SHOULD include 'scaled' if a logical percent based score is known.
-* The Score Object SHOULD NOT be used for scores relating to progress or completion.  Consider using an extension
-from an extension profile instead.
+* The Score Object SHOULD NOT be used for scores relating to progress or completion.  Consider using an <a href="https://github.com/adlnet/xAPI-Spec/blob/master/xAPI.md#miscext">extension</a> instead.
 
 
 <a name="context"/>
@@ -1709,7 +1716,7 @@ the qualification relates to the class as the grouping.
 
 3. __Category__: an Activity used to categorize the Statement.
 "Tags" would be a synonym. Category SHOULD be used to indicate
-a "profile" of xAPI behaviors, as well as other categorizations.
+a <a href="#def-community-profile">community profile</a> of xAPI behaviors, as well as other categorizations.
 For example: Anna attempts a biology exam, and the Statement is
 tracked using the CMI-5 profile. The Statement's Activity refers
 to the exam, and the category is the CMI-5 profile.

--- a/xAPI.md
+++ b/xAPI.md
@@ -3309,14 +3309,14 @@ include attachment raw data and MUST report application/json.
 
 ###### Filter Conditions for StatementRefs 
 
-This section outlines rules by which additional Statements are considered to meet the filter coniditions even
-if they do not match the original query's filter parameters but instead target a Statement which does. 
+This section outlines rules by which Statements targeting other Statements can sometimes be considered to 
+meet the filter conditions of a query even if they do not match the original query's filter parameters. 
 These rules **do not** apply when retrieving a single Statement with statementId or voidedStatementId.
 
 For filter parameters which are not time or sequence based (that is, other than since, until, or limit), 
 Statements which target another Statement (by using a StatementRef
 as the Object of the Statement) will meet the filter condition if the targeted Statement meets 
-the condition of that filter parameter.
+the filter condition.
 
 The time and sequence based parameters MUST still be applied to the Statement 
 making the StatementRef in this manner. This rule applies recursively, so that "Statement a" is a 

--- a/xAPI.md
+++ b/xAPI.md
@@ -2796,9 +2796,9 @@ is included in [Appendix F: Table of All Endpoints](#AppendixF).
 
 ###### Requirements
 
-* The LRS MUST support all of the endpoints described in [this section](#datatransfer). (__Note:__ This requirement *does not* apply to 
-the OAuth endpoints described in [Section 6.4.2 OAuth Authorization Scope](#oauthscope); see that section for requirements relating to
-the OAuth endpoints.) 
+* The LRS MUST support all of the endpoints described in [this section](#datatransfer). 
+* If the LRS implements OAuth 1.0, the LRS MUST also support all of the OAuth endpoints 
+described in [Section 6.4.2 OAuth Authorization Scope](#oauthscope).
 
 <a name="errorcodes" /> 
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -3425,19 +3425,18 @@ the resulting document stored in the LRS is:
 	"z" : "faz"
 }
 ```
-If the original document exists, and the original document or the document being posted
-do not have a Content-Type:
-of "application/json", or if either document cannot be parsed as JSON Objects, the LRS MUST
+
+###### Requirements
+
+* If the document being posted or any existing document do not have a Content-Type
+of "application/json", or if either document cannot be parsed as a JSON Object, the LRS MUST
 respond with HTTP status code ```400 Bad Request```, and MUST NOT update the target document
 as a result of the request.
 
-If the original document does not exist, the LRS MUST treat the request the same as it 
-would a PUT request and store the document being posted.
-
-If the merge is successful, the LRS MUST respond with HTTP 
+* If the merge is successful, the LRS MUST respond with HTTP 
 status code ```204 No Content```.
 
-If an AP needs to delete
+* If an AP needs to delete
 a property, it SHOULD use a PUT request to replace the whole document as described below. 
 
 <a name="stateapi"/> 

--- a/xAPI.md
+++ b/xAPI.md
@@ -3004,8 +3004,8 @@ do not match.
 
 ###### Activity Provider Requirements
 
-* Activity Providers SHOULD use POST instead of PUT. 
-* When PUTing statements, the "id" property of the Statement SHOULD* be used. 
+* Activity Providers SHOULD POST Statements including the Statement "id" property instead of using PUT. 
+* When PUTing statements, the "id" property of the Statement SHOULD be used. 
 * Where provided, the "id" property of the Statement MUST match the "statementId" parameter of the request. 
 
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -1194,7 +1194,9 @@ Run-Time Environment. See [Appendix C](#AppendixC) for examples of each format.
 	</tr>
 	<tr>
 		<td>numeric</td>
-		<td>A range of numbers represented by a minimum and a maximum delimited by <code>:</code>.
+		<td>A range of numbers represented by a minimum and a maximum delimited by <code>[:]</code>. 
+			Where the correct response or learner's response is a single number rather than a range, the single number
+			with no delimiter MAY be used. 
 		</td>
 	</tr>
 	<tr>
@@ -1258,9 +1260,8 @@ Interaction components are defined as follows:
 	<tr>
 		<td>id</td>
 		<td>String</td>
-		<td>A value such as used in practice for "cmi.interactions.n.id" as
-            defined in the SCORM 2004 4th Edition Run-Time Environment</td>
-            	<td>Required</td>
+		<td>Identifies the interaction component within the list.</td>
+        <td>Required</td>
 	<tr>
 		<td>description</td>
 		<td><a href="#misclangmap">Language Map</a></td>
@@ -1533,7 +1534,7 @@ The table below defines the Score Object.
 	</tr>
 </table>
 
-The properties of the score object are based on the corresponding properties of cmi.score as defined in SCORM 2004 
+The properties of the score object were originally based on the corresponding properties of cmi.score as defined in SCORM 2004 
 4th Edition. 
 
 ###### Requirements
@@ -4491,7 +4492,7 @@ This example shows a SubStatement object whose object is a Statement Reference.
 	"type": "http://adlnet.gov/expapi/activities/cmi.interaction",
 	"interactionType": "numeric",
 	"correctResponsesPattern": [
-		"4:"
+		"4[:]"
 	]
 }
 ```

--- a/xAPI.md
+++ b/xAPI.md
@@ -2470,12 +2470,13 @@ Using Semantic Versioning will allow Clients and LRSs to reliably know compatibi
 ###### Details
 
 Starting with 1.0.0, xAPI will be versioned according to [Semantic Versioning 1.0.0](http://semver.org/spec/v1.0.0.html).  Every request from a Client and every response from the LRS includes an HTTP header with the name 
-“X-Experience-API-Version" and the version as the value. For example, ``X-Experience-API-Version : 1.0.3``
+“X-Experience-API-Version" and the version as the value. For example, ``X-Experience-API-Version : 1.0.3`` for version 1.0.3; 
+see the [Revision History](#revhistory) for the current version of this specification. 
 
 ###### LRS Requirements
 
 * The LRS MUST include the "X-Experience-API-Version" header in every response.
-* The LRS MUST set this header to "1.0.3".
+* The LRS MUST set this header to the latest patch version.
 * The LRS MUST accept requests with a version header of "1.0" as if the version header was "1.0.0".
 * The LRS MUST reject requests with version header prior to "1.0.0" unless such requests are routed to a 
 fully conformant implementation of the prior version specified in the header.
@@ -2486,7 +2487,7 @@ of the problem.
 ###### Client Requirements
 
 * The Client MUST include the "X-Experience-API-Version" header in every request.
-* The Client MUST set this header to "1.0.3".
+* The Client MUST set this header to the latest patch version.
 * The Client SHOULD tolerate receiving responses with a version of "1.0.0" or later.
 * The Client SHOULD tolerate receiving data structures with additional properties.
 * The Client SHOULD ignore any properties not defined in version 1.0.0 of the spec.

--- a/xAPI.md
+++ b/xAPI.md
@@ -1832,7 +1832,7 @@ The two Agents represent an application and user together.
 * The LRS MUST include the user as an Agent as the entire authority if a user connects 
 directly (using HTTP Basic Authentication) or is included as part of a Group. 
 * The LRS MUST ensure that all Statements stored have an authority.
-* The LRS SHOULD overwrite the authority on all stored received Statements, 
+* The LRS SHOULD overwrite the authority on all Statements it stores,
 based on the credentials used to send those Statements.
 * The LRS MAY leave the submitted authority unchanged but SHOULD do so only 
 where a strong trust relationship has been established, and with extreme caution.

--- a/xAPI.md
+++ b/xAPI.md
@@ -313,6 +313,8 @@ be unintuitive and/or lengthy to dissect into a list of requirements.
 * [Inverse Functional Identifier](#def-inverse-functional-identifier)
 * [Learning Management System (LMS)](#def-learning-management-system)
 * [Learning Record Store (LRS)](#def-learning-record-store)
+* [Metadata Provider](#def-metadata-provider)
+* [Metadata Consumer](#def-metadata-consumer)
 * [MUST / SHOULD / MAY](#def-must-should-may)
 * [Profile](#def-profile)
 * [Registration](#def-registration)
@@ -417,6 +419,17 @@ __Learning Record Store (LRS)__: A system that stores learning information. Prio
 most LRSs were Learning Management Systems (LMSs); however this document uses the term 
 LRS to be clear that a full LMS is not necessary to implement the xAPI. The xAPI 
 is dependent on an LRS to function.
+
+<a name="def-metadata-consumer" />
+
+__Metadata Consumer__: A person, organization, software program or other thing that seeks to determine the meaning represented
+by an IRI used within this specification and/or retrieves metadata from an IRL used as an IRI within this specification. An LRS may or
+may not be a metadata consumer. 
+
+<a name="def-metadata-provider" />
+
+__Metadata Provider__: A person, organization, software program or other thing that coins IRIs to be used within this specification and/or
+hosts metadata an IRL used as an IRI within this specification. 
 
 <a name="def-must-should-may" />
 
@@ -2422,21 +2435,33 @@ identifier it describes.  We recommend that
 Activity Providers look for and use established, widely adopted identifiers for all types of IRI 
 identifiers other than Activity id.
 
-##### Requirements
+##### Metadata Provider Requirements
 
 * Metadata MAY be provided with an identifier.
 * If metadata is provided, both name and description SHOULD be included.
-* IRLs SHOULD be defined within a domain controlled by the person creating the IRL.
+* IRLs SHOULD be defined within a domain controlled by the [Metadata Provider](#def-metadata-provider) creating the IRL.
 * For any of the identifier IRIs above, if the IRI is an IRL created for use with this
-specification, the controller of that IRL SHOULD make this JSON metadata available at that 
+specification, the Metadata Provider SHOULD ensure that this JSON metadata available at that 
 IRL when the IRL is requested and a Content-Type of "application/json" is requested.
-* Where an identifier already exists, the Activity Provider SHOULD use the corresponding existing identifier.
-* The Activity Provider MAY create and use their own identifiers where a suitable identifier does not already exist.
-* When defining identifiers, the Activity Provider MAY use URIs containing anchors so that a single page can contain definitions for multiple identifiers. E.g. http://example.com/xapi/verbs#defenestrated
-* Other sources of information MAY be used to fill in missing details, such as translations, or
-take the place of this metadata entirely if it was not provided or cannot be loaded. This MAY
+* Where a suitable identifier already exists, the Metadata Provider SHOULD NOT create a new identifier.
+* The Metadata Provider MAY create their own identifiers where a suitable identifier does not already exist.
+* When defining identifiers, the Metadata Provider MAY use IRLs containing anchors so that a single page can contain definitions for multiple identifiers. E.g. http://example.com/xapi/verbs#defenestrated
+
+##### Activity Provider Requirements
+* Where a suitable identifier already exists, the Activity Provider SHOULD use the corresponding existing identifier.
+
+##### LRS Requirements
+* The LRS MAY act as a [Metadata Consumer](#def-metadata-consumer) and attempt to resolve identifier IRIs that are IRLs.
+
+##### Metadata Consumer Requirements
+* If a Metadata Consumer obtains metadata from an IRL, it SHOULD make a strong presumption that the 
+metadata found at that IRL is authoritative in regards to the properties and languages included in that metadata. 
+* The Metadata Consumer MAY use other sources of information to fill in missing details, 
+such as translations, or take the place of the hosted metadata entirely if it was not provided, cannot be loaded or the 
+Metadata Consumer does not trust it. Other sources of information MAY
 include metadata in other formats stored at the IRL of an identifier, particularly if that
 identifier was not coined for use with this specification.
+
 
 <a name="rtcom"/>
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -445,7 +445,6 @@ Whilst these recommendations cannot be MUST requirements within this version (as
 the xAPI Working Group strongly encourages adopters to implement these requirements as though they were MUST requirements, 
 whilst continuing to support other adopters that might not do so.
 
-
 <a name="def-profile" />
 
 __Profile__: A construct where information about the learner or activity is kept, 

--- a/xAPI.md
+++ b/xAPI.md
@@ -3196,8 +3196,8 @@ Returns: ```200 OK```, Statement or [Statement Result](#retstmts) (See [Section 
 	</tr>
 	<tr>
 		<td>attachments</td><td>Boolean</td><td>false</td>
-		<td>If "true", the LRS uses the multipart response format and includes all attachments as 
-		described previously.  If "false", the LRS sends the prescribed response with Content-Type 
+		<td>If <code>true</code>, the LRS uses the multipart response format and includes all attachments as 
+		described previously.  If <code>false</code>, the LRS sends the prescribed response with Content-Type 
 		application/json and cannot use attachments.</td>
 		<td>Optional</td>
 	</tr>
@@ -3205,7 +3205,7 @@ Returns: ```200 OK```, Statement or [Statement Result](#retstmts) (See [Section 
 		<td>ascending</td>
 		<td>Boolean</td>
 		<td>false</td>
-		<td>If "true", return results in ascending order of stored time</td>
+		<td>If <code>true</code>, return results in ascending order of stored time</td>
 		<td>Optional</td>
 	</tr>
 </table>
@@ -3236,10 +3236,10 @@ are known with reasonable certainty to be available for retrieval. This time SHO
 account any temporary condition, such as excessive load, which might cause a delay in Statements 
 becoming available for retrieval.
 
-* If the attachment property of a GET statement is used and is set to "true", the LRS MUST use the 
+* If the attachment property of a GET statement is used and is set to <code>true</code>, the LRS MUST use the 
 multipart response format and include all attachments as described in <a href="#attachments">4.1.11</a>.
 
-* If the attachment property of a GET statement is used and is set to "false", the LRS MUST NOT
+* If the attachment property of a GET statement is used and is set to <code>false</code>, the LRS MUST NOT
 include attachment raw data and MUST report application/json.
 
 <a name="queryStatementRef" />

--- a/xAPI.md
+++ b/xAPI.md
@@ -1563,7 +1563,7 @@ The table below defines the Score Object.
 	</tr>
 </table>
 
-The properties of the score object are based on the corresponding properties of cmi.score as defined in SCORM 2004 
+The properties of the Score Object are based on the corresponding properties of cmi.score as defined in SCORM 2004 
 4th Edition. If both "scaled" and "raw" properties are provided, the exact relationship between their two values is determined 
 by the Activity Provider or their Community of Practice; scaling and normalization are out of scope of this specification.
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -1224,7 +1224,7 @@ Run-Time Environment. See [Appendix C](#AppendixC) for examples of each format.
 
 ###### Characterstring parameters
 Some of the values within the responses described above can be prepended with certain additional parameters. These were originally based on the characterstring
-delimiters defined in the SCORM 2004 4th Edition Run-Time Environment. These parameters are represented by the format ```{parameter=value}```. See
+delimiters defined in the SCORM 2004 4th Edition Run-Time Environment. These parameters are represented by the format ```{parameter=value}```.
 See [the long-fill-in example within Appendix C](#long-fill-in). 
 
 The following parameters are valid at the start of the string representing the list of items for the listed interaction types:

--- a/xAPI.md
+++ b/xAPI.md
@@ -1564,8 +1564,9 @@ The table below defines the Score Object.
 </table>
 
 The properties of the Score Object are based on the corresponding properties of cmi.score as defined in SCORM 2004 
-4th Edition. If both "scaled" and "raw" properties are provided, the exact relationship between their two values is determined 
-by the Activity Provider or their Community of Practice; scaling and normalization are out of scope of this specification.
+4th Edition. The "scaled" and "raw" properties do not necessarily relate directly as scaling and normalization can
+be applied differently by Activity Providers within different Communities of Practice. Scaling and normalization are 
+outside the scope of this specification.
 
 ###### Requirements
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -2490,7 +2490,6 @@ Metadata Consumer does not trust it. Other sources of information MAY
 include metadata in other formats stored at the IRL of an identifier, particularly if that
 identifier was not coined for use with this specification.
 
-
 <a name="rtcom"/>
 
 ## 6.0 Run-time Communication

--- a/xAPI.md
+++ b/xAPI.md
@@ -1525,10 +1525,8 @@ The table below defines the Score Object.
 	<tr>
 		<td>scaled</td>
 		<td>Decimal number between -1 and 1, inclusive</td>
-		<td>The score related to the experience as a proportion of the maximum score possible for the experience. 
-		In the case of negative score, the scaled score is calculated as a proportion of the minimum score possible.
-		For positive scores, the scaled score can be calculated as the raw score divided by the max score (where
-		those values are present). </td>
+		<td>The score related to the experience as modified by scaling and/or normalization. 
+		</td>
 		<td>Recommended</td>
 	</tr>
 	<tr>
@@ -1553,7 +1551,8 @@ The table below defines the Score Object.
 </table>
 
 The properties of the score object are based on the corresponding properties of cmi.score as defined in SCORM 2004 
-4th Edition. 
+4th Edition. If both scaled and raw score are provided, the exact relationship between the scaled and raw score is determined 
+by the Activity Provider or their Community of Practice; scaling and normalization are out of scope of this specification.
 
 ###### Requirements
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -19,12 +19,12 @@
 
 ## Table of Contents
 *	1.0.	[Revision History](#revhistory)  
-*	2.0.	[Role of the Experience API](#roleofxapi)
+*	2.0.	[Role of the Experience API](#roleofxapi)  
 	*	2.1.	[ADL's Role in the Experience API](#adlrole)  
- 	*	2.2.	[Contributors](#contributors)
+ 	*	2.2.	[Contributors](#contributors)  
  		*	2.2.1.	[Working Group Participants](#wg)  
-		*	2.2.2.	[Requirements Gathering Participants](#reqparticipants) 
-	*	2.3.	[Reading Guidelines for the Non-Technically Inclined](#readingguidelines)
+		*	2.2.2.	[Requirements Gathering Participants](#reqparticipants)  
+	*	2.3.	[Reading Guidelines for the Non-Technically Inclined](#readingguidelines)  
 *	3.0.	[Definitions](#definitions)  
 *	4.0.	[Statement](#statement)  
     *	4.1.	[Statement Properties](#stmtprops)  
@@ -57,26 +57,27 @@
 		*	6.4.2.	[OAuth Authorization Scope](#oauthscope)  
 *	7.0.	[Data Transfer (REST)](#datatransfer)  
     *	7.1.	[Error Codes](#errorcodes)  
-    *	7.2.	[Statement API](#stmtapi)
-    	*	7.2.1. [PUT Statements](#stmtapiput)
-    	*	7.2.2. [POST Statements](#stmtapipost)
-    	*	7.2.3. [GET Statements](#stmtapiget)
-    	*	7.2.4. [Voided Statements](#voidedStatements)	  
-    *	7.3.	[Document APIs](#docapis)  
-    *	7.4.	[State API](#stateapi)  
-    *	7.5.	[Activity Profile API](#actprofapi)  
-    *	7.6.	[Agent Profile API](#agentprofapi)  
-    *	7.7.	[About resource](#aboutresource)  
-    *	7.8.	[Cross Origin Requests](#cors)  
-    *	7.9.	[Validation](#validation)  
-    *	7.10.	[HTTP HEAD](#httphead)  
+    *	7.2.	[Header Parameters](#header-parameters)  
+    *	7.3.	[Statement API](#stmtapi)  
+    	*	7.3.1. [PUT Statements](#stmtapiput)  
+    	*	7.3.2. [POST Statements](#stmtapipost)  
+    	*	7.3.3. [GET Statements](#stmtapiget)  
+    	*	7.3.4. [Voided Statements](#voidedStatements)  
+    *	7.4.	[Document APIs](#docapis)  
+    *	7.5.	[State API](#stateapi)  
+    *	7.6.	[Activity Profile API](#actprofapi)  
+    *	7.7.	[Agent Profile API](#agentprofapi)  
+    *	7.8.	[About resource](#aboutresource)  
+    *	7.9.	[Cross Origin Requests](#cors)  
+    *	7.10.	[Validation](#validation)  
+    *	7.11.	[HTTP HEAD](#httphead)  
 *	[Appendix A: Example Statements](#AppendixA)  
 *	[Appendix B: Example statement objects of different types](#AppendixB)  
 *	[Appendix C: Example definitions for Activities of type "cmi.interaction"](#AppendixC)  
-*	[Appendix D: Converting Statements to 1.0.0](#AppendixD)   
-*	[Appendix E: Example Signed Statement](#AppendixE)
-*	[Appendix F: Table of All Endpoints](#AppendixF)
-*	[Appendix G: Cross Domain Request Example](#AppendixG)
+*	[Appendix D: Converting Statements to 1.0.0](#AppendixD)  
+*	[Appendix E: Example Signed Statement](#AppendixE)  
+*	[Appendix F: Table of All Endpoints](#AppendixF)  
+*	[Appendix G: Cross Domain Request Example](#AppendixG)  
 
 
 <a name="revhistory"/>  
@@ -1982,7 +1983,7 @@ capability will be available when issuing PUT or POST against the Statement reso
 ###### LRS Requirements
 
 * An LRS MUST include attachments in the Transmission Format described above
-when requested by the Client (see Section [7.2 "Statement API"](#stmtapi)).
+when requested by the Client (see Section [7.3 "Statement API"](#stmtapi)).
 * An LRS MUST NOT pull Statements from another LRS without requesting attachments.
 * An LRS MUST NOT push Statements into another LRS without including attachment data
 received, if any, for those attachments.
@@ -2138,7 +2139,7 @@ LRS SHOULD* reject Statements containing such additional properties.
 
 ###### Description
 A collection of Statements can be retrieved by performing a query on the "statements" 
-endpoint, see Section [7.2 "Statement API"](#stmtapi) for details. 
+endpoint, see Section [7.3 "Statement API"](#stmtapi) for details. 
 
 ###### Details
 The following table shows the data structure for the results of queries on the Statement API.
@@ -2210,7 +2211,7 @@ again under a new id.
 
 __Note:__ See ["Statement References"](#stmtref) in [Section 4.1.4.3 When the "Object" is a Statement](#stmtasobj) 
 for details about making references to other Statements.  To see how voided statements behave when queried, 
-See [StatementRef](#queryStatementRef) in 7.2 Statement API).
+See [StatementRef](#queryStatementRef) in 7.3 Statement API).
 
 ###### Example
 
@@ -2804,7 +2805,7 @@ section [6.4.2](#oauthscope).
 Permissions can also affect the response returned by an LRS to GET requests. For example, 
 a set of credentials might have permission only to view statements about a particular actor, in which case
 the LRS will filter any returned statements to exclude any statements not relating to that actor. See 
-[Section 7.2.3 GET Statements](#stmtapiget) for details. 
+[Section 7.3.3 GET Statements](#stmtapiget) for details. 
 
 In cases explicitly allowed by this specification, the credentials used can also affect the LRS behaviour in 
 handling a request, for example the LRS will normally overwrite the Authority property of a Statement, but can 
@@ -2914,9 +2915,39 @@ This set of credentials SHOULD* be used for conformance testing but MAY be delet
 
 * The LRS MUST be configurable to accept requests at any reasonable rate. 
 
+<a name="header-parameters"/> 
+### 7.2 Header Parameters
+Some header parameters used within xAPI data transfer are 
+[standard HTTP headers](http://en.wikipedia.org/wiki/List_of_HTTP_header_fields). Others are specific to this
+ specification. The following request headers are expected to be used by the Activity Provider in some or all 
+ of the types of request and situations described in this specification:
+
+* Accept
+* Accept-Encoding
+* Accept-Language
+* Authorization
+* Content-Type
+* Content-Length
+* Content-Transfer-Encoding
+* If-Match
+* If-None-Match
+* X-Experience-API-Version 
+
+The following response headers are expected to be used by the LRS. Again, not all of these apply
+to every type of request and/or situations:
+
+* Content-Type
+* Content-Length
+* ETag
+* Status
+* X-Experience-API-Version
+* X-Experience-API-Consistent-Through
+
+The lists above are not intended to be exhaustive. See requirements throughout this document for more details.
+
 <a name="stmtapi"/> 
 
-### 7.2 Statement API
+### 7.3 Statement API
 
 ###### Description
 
@@ -2925,7 +2956,7 @@ The basic communication mechanism of the Experience API.
 
 <a name="stmtapiput"/>
 
-####7.2.1 PUT Statements
+####7.3.1 PUT Statements
 
 ###### Details
 
@@ -2956,7 +2987,7 @@ do not match.
 
 <a name="stmtapipost"/>
 
-####7.2.2 POST Statements
+####7.3.2 POST Statements
 
 ###### Details
 
@@ -2986,14 +3017,14 @@ do not match.
 * The LRS MAY respond before Statements that have been stored are available for retrieval.
 
 * GET Statements MAY be called using POST and form parameters if necessary as query strings 
-have limits. See Section [7.8 Cross Origin Requests](#78-cross-origin-requests) for more details.
+have limits. See Section [7.9 Cross Origin Requests](#79-cross-origin-requests) for more details.
 
 * The LRS MUST differentiate a POST to add a Statement or to list Statements based on the 
-parameters passed. See Section [7.8 Cross Origin Requests](#78-cross-origin-requests) for more details.
+parameters passed. See Section [7.9 Cross Origin Requests](#79-cross-origin-requests) for more details.
 
 <a name="stmtapiget"/>
 
-####7.2.3 GET Statements
+####7.3.3 GET Statements
 
 ###### Details
 
@@ -3235,7 +3266,7 @@ which language entry to include, rather than to the resource (list of Statements
 
 <a name="voidedStatements" />
 
-####7.2.4 Voided Statements
+####7.3.4 Voided Statements
 
 ###### Requirements
 
@@ -3254,7 +3285,7 @@ voidedStatementId.
 
 <a name="docapis" />
 
-### 7.3 Document APIs
+### 7.4 Document APIs
 
 The three Document APIs provide [document](#miscdocument) storage for learning activity 
 providers and Agents. The details of each API are found in the following sections, and the 
@@ -3358,7 +3389,7 @@ a property, it SHOULD use a PUT request to replace the whole document as describ
 
 <a name="stateapi"/> 
 
-### 7.4 State API
+### 7.5 State API
 
 ##### Description
 
@@ -3478,7 +3509,7 @@ Returns: ```204 No Content```
 
 <a name="actprofapi"/> 
 
-### 7.5 Activity Profile API
+### 7.6 Activity Profile API
 
 ###### Description
 
@@ -3561,7 +3592,7 @@ Returns: ```200 OK```, List of ids
 
 <a name="agentprofapi"/> 
 
-### 7.6 Agent Profile API
+### 7.7 Agent Profile API
 
 ###### Description
 
@@ -3721,7 +3752,7 @@ Returns: ```200 OK```, List of ids
 
 <a name="aboutresource"/> 
 
-### 7.7 About Resource
+### 7.8 About Resource
 
 ###### Description
 
@@ -3774,7 +3805,7 @@ required by <a href="#apiversioning"/>6.2 API Versioning</a>.
 
 <a name="cors"/>
 
-### 7.8 Cross Origin Requests
+### 7.9 Cross Origin Requests
 
 ###### Description
 
@@ -3853,7 +3884,7 @@ See [Appendix G: Cross Domain Request Example](#AppendixG) for an example.
 
 <a name="validation"/> 
 
-### 7.9 Validation
+### 7.10 Validation
 
 ###### Description
 
@@ -3871,7 +3902,7 @@ responsibility of the Activity Provider sending the Statement.
 
 <a name="httphead"/>
 
-### 7.10 HTTP HEAD
+### 7.11 HTTP HEAD
 
 ###### Description
 The LRS will respond to HEAD requests by returning the meta information only, using 
@@ -4880,7 +4911,7 @@ attachment message format.
 
 ## Appendix G: Cross Domain Request example
 
-Section [7.8 Cross Origin Requests](#78-cross-origin-requests) outlines alternative syntax for use 
+Section [7.9 Cross Origin Requests](#79-cross-origin-requests) outlines alternative syntax for use 
 when the normal syntax cannot be used due to browser or querystring length restrictions. This appendix provides an example of a
 PUT statements request following this format. 
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -2062,8 +2062,8 @@ designers of systems that will send Statements using the "fileUrl" property are 
 consider the needs of end recipient(s) of the Statement especially if the attachment content 
 is not included with the Statement.
 
-* The attachment data SHOULD be retirevable at the IRL indicated by the fileUrl.
-* The file host MAY stop providing the attachment data at this IRL at any time. 
+* The attachment data SHOULD be retrievable at the URL indicated by the fileUrl.
+* The owner of the attachment MAY stop providing the attachment data at this IRL at any time. 
 * Security restrictions MAY be applied to clients attempting to access the attachment data at this IRL. 
 
 The duration an attachment is made available for, and the security restrictions applied to

--- a/xAPI.md
+++ b/xAPI.md
@@ -1422,6 +1422,7 @@ action. The concrete example that follows logically states that
 			} 
 		},
 		"object": {
+			"objectType": "Activity",
 			"id":"http://example.com/website",
 			"definition": { 
 				"name" : {

--- a/xAPI.md
+++ b/xAPI.md
@@ -3339,7 +3339,7 @@ The LRS MUST return only one language in each of these maps.
 
 * The LRS MAY maintain canonical versions of language maps for any language map used in an object
 which has an id (objects without an id could never be matched to a canonical definition). 
-This includes the Verb Display property and some properties used within extensions. 
+This includes the Verb Display property and any language maps used within extensions. 
 
 * If the LRS maintains a canonical version of a language map, it SHOULD* return this when canonical 
 format is used. 

--- a/xAPI.md
+++ b/xAPI.md
@@ -432,13 +432,13 @@ is dependent on an LRS to function.
 <a name="def-metadata-consumer" />
 
 __Metadata Consumer__: A person, organization, software program or other thing that seeks to determine the meaning represented
-by an IRI used within this specification and/or retrieves metadata from an IRL used as an IRI within this specification. An LRS may or
-may not be a metadata consumer. 
+by an IRI used within this specification and/or retrieves metadata about an IRI. An LRS might or
+might not be a metadata consumer. 
 
 <a name="def-metadata-provider" />
 
 __Metadata Provider__: A person, organization, software program or other thing that coins IRIs to be used within this specification and/or
-hosts metadata an IRL used as an IRI within this specification. 
+hosts metadata about an IRI. 
 
 <a name="def-must-should-may" />
 
@@ -2179,7 +2179,7 @@ Statements would mean that the Statement would not be interoperable with all LRS
       an enumerated value given in this specification exactly.
     * where a key or value is not allowed by this specification.
     * where a key occurs multiple times within an object. 
-* The LRS MUST reject Statements containing IRL, IRI, or IRI values without a scheme.
+* The LRS MUST reject Statements containing IRL or IRI values without a scheme.
 * The LRS MUST at least validate that the sequence of token lengths for language map keys
 matches the [RFC 5646](http://tools.ietf.org/html/rfc5646) standard.
 * The LRS MUST process and store numbers with at least the precision of IEEE 754 32-bit
@@ -2187,7 +2187,7 @@ floating point numbers.
 * The LRS MUST validate parameter values to the same standards required for values of the
 same types in Statements. __Note:__ string parameter values are not quoted as they are in JSON.
 * The LRS SHOULD treat all values as case sensitive unless specified otherwise.
-* The LRS MAY use best-effort validation for IRL, IRI, and IRI formats to satisfy the
+* The LRS MAY use best-effort validation for IRL and IRI formats to satisfy the
 non-format-following rejection requirement.
 * The LRS MAY use best-effort validation for language map keys to satisfy the
 non-format-following rejection requirement.
@@ -2475,27 +2475,27 @@ identifiers other than Activity id.
 
 * Metadata MAY be provided with an identifier.
 * If metadata is provided, both name and description SHOULD be included.
-* IRLs SHOULD be defined within a domain controlled by the [Metadata Provider](#def-metadata-provider) creating the IRL.
-* For any of the identifier IRIs above, if the IRI is an IRL created for use with this
-specification, the Metadata Provider SHOULD ensure that this JSON metadata available at that 
-IRL when the IRL is requested and a Content-Type of "application/json" is requested.
+* IRIs SHOULD be defined within a domain controlled by the [Metadata Provider](#def-metadata-provider) creating the IRI.
+* For any of the identifier IRIs above the Metadata Provider SHOULD ensure that this JSON metadata available at that 
+IRI when the IRI is requested and a Content-Type of "application/json" is requested.
 * Where a suitable identifier already exists, the Metadata Provider SHOULD NOT create a new identifier.
 * The Metadata Provider MAY create their own identifiers where a suitable identifier does not already exist.
-* When defining identifiers, the Metadata Provider MAY use IRLs containing anchors so that a single page can contain definitions for multiple identifiers. E.g. http://example.com/xapi/verbs#defenestrated
+* When defining identifiers, the Metadata Provider MAY use IRIs containing anchors so that a single page can contain 
+definitions for multiple identifiers. E.g. http://example.com/xapi/verbs#defenestrated
 
 ##### Activity Provider Requirements
 * Where a suitable identifier already exists, the Activity Provider SHOULD use the corresponding existing identifier.
 
 ##### LRS Requirements
-* The LRS MAY act as a [Metadata Consumer](#def-metadata-consumer) and attempt to resolve identifier IRIs that are IRLs.
+* The LRS MAY act as a [Metadata Consumer](#def-metadata-consumer) and attempt to resolve identifier IRIs.
 
 ##### Metadata Consumer Requirements
-* If a Metadata Consumer obtains metadata from an IRL, it SHOULD make a strong presumption that the 
-metadata found at that IRL is authoritative in regards to the properties and languages included in that metadata. 
+* If a Metadata Consumer obtains metadata from an IRI, it SHOULD make a strong presumption that the 
+metadata found at that IRI is authoritative in regards to the properties and languages included in that metadata. 
 * The Metadata Consumer MAY use other sources of information to fill in missing details, 
 such as translations, or take the place of the hosted metadata entirely if it was not provided, cannot be loaded or the 
 Metadata Consumer does not trust it. Other sources of information MAY
-include metadata in other formats stored at the IRL of an identifier, particularly if that
+include metadata in other formats stored at the IRI of an identifier, particularly if that
 identifier was not coined for use with this specification.
 
 <a name="rtcom"/>

--- a/xAPI.md
+++ b/xAPI.md
@@ -438,6 +438,9 @@ specification. A system that fails to implement a MUST (or a MUST NOT) requireme
 Failing to meet a SHOULD requirement is not a violation of conformity, but goes against best practices. 
 MAY indicates an option, to be decided by the developer with no consequences for conformity.
 
+The use of an asterisk* following SHOULD indicates a very strong recommendation. It is likely that
+these recommendations will become MUST requirements in a future version. 
+
 <a name="def-profile" />
 
 __Profile__: A construct where information about the learner or activity is kept, 

--- a/xAPI.md
+++ b/xAPI.md
@@ -515,7 +515,7 @@ The details of each property of a statement are described in the table below.
 	<td>Not Recommended</td></tr>
 	<tr>
 		<td><a href="#attachments">attachments</a></td>
-		<td>Array of attachment Objects</td>
+		<td>Ordered array of Attachment Objects</td>
 	    <td>Headers for attachments to the Statement</td>
 	<td>Optional</td></tr>
 </table>  
@@ -1898,7 +1898,7 @@ in and retrieve them from an LRS. In the case of wanting to include an attachmen
 ###### Details
 The table below lists all properties of the Attachment object.
 <table>
-	<tr><th>Property</th><th>Type</th><th>Description</th><th>Required</th></tr>
+	<tr><th>Property</th><th>Type</th><th>Description</th><th>Required</th><th>Corresponding request parameter</th></tr>
 	<tr>
 		<a name="attachmentUsage" />
 
@@ -1908,30 +1908,35 @@ The table below lists all properties of the Attachment object.
 		for attachments is to include a "completion certificate". A type IRI corresponding
 		to this usage MUST be coined, and used with completion certificate attachments.</td>
 		<td>Required</td>
+		<td></td>
 	</tr>
 	<tr>
 		<td>display</td>
 		<td><a href="#misclangmap">Language Map</a></td>
 		<td>Display name (title) of this attachment.</td>
 		<td>Required</td>
+		<td></td>
 	</tr>
 	<tr>
 		<td>description</td>
 		<td><a href="#misclangmap">Language Map</a></td>
 		<td>A description of the attachment</td>
 		<td>Optional</td>
+		<td></td>
 	</tr>
 	<tr>
 		<td>contentType</td>
 		<td><a href="https://www.ietf.org/rfc/rfc2046.txt?number=2046">Internet Media Type</a></td>
 		<td>The content type of the attachment.</td>
 		<td>Required</td>
+		<td>Content-Type</td>
 	</tr>
 	<tr>
 		<td>length</td>
 		<td>Integer</td>
 		<td>The length of the attachment data in octets.</td>
 		<td>Required</td>
+		<td>Content-Length</td>
 	</tr>
 	<tr>
 		<td>sha2</td>
@@ -1939,13 +1944,15 @@ The table below lists all properties of the Attachment object.
 		<td>The SHA-2 (SHA-256, SHA-384, SHA-512) hash of the attachment data. SHA-224 
 		SHOULD not be used: a minimum key size of 256 bits is recommended.</td>
 		<td>Required</td>
+		<td>X-Experience-API-Hash</td>
 	</tr>
 	<tr>
 		<td>fileUrl</td>
 		<td>IRL</td>
 		<td>An IRL at which the attachment data can be retrieved, or from which it used 
 		to be retrievable. </td>
-		<td>Optional</td>
+        <td>Optional</td>
+		<td></td>
 	</tr>
 </table>
 
@@ -1972,13 +1979,13 @@ results when the attachments filter is false.
 * It MUST conform to the definition of multipart/mixed in [RFC 1341](http://www.w3.org/Protocols/rfc1341/7_2_Multipart.html) and:
     * The first part of the multipart document MUST contain the Statements themselves, with type "application/json".
     * Each additional part contains the raw data for an attachment and forms a logical part of the Statement. This 
-capability will be available when issuing PUT or POST against the Statement resource.
-	* MUST include an X-Experience-API-Hash parameter in each part's header after the first (Statements) part.
-	* This parameter MUST be set to match the "sha2" property of the attachment declaration corresponding to the 
-	attachment included in this part.
-	* MUST include a Content-Transfer-Encoding parameter with a value of "binary" in each part's header after the first (statements) part.
+    capability will be available when issuing PUT or POST against the Statement resource.
+    * MUST include an X-Experience-API-Hash parameter in each part's header after the first (Statements) part.
+    * MUST include a Content-Transfer-Encoding parameter with a value of "binary" in each part's header after the first (statements) part.
     * SHOULD only include one copy of an attachment's data when the same attachment is used in multiple Statements that are sent together.
-    * SHOULD include a Content-Type parameter in each part's header, for the first part this MUST be "application/json".
+    * SHOULD include a Content-Type parameter in each part's header, for the first part (containing the statement) this MUST be "application/json".
+    * Where parameters have a corresponding property within the Attachment Object (outlined in the table above), the value of these parameters and properties
+    for each Attachment MUST match. 
 
 
 ###### LRS Requirements

--- a/xAPI.md
+++ b/xAPI.md
@@ -2318,7 +2318,7 @@ for discoverability of the signer X.509 certificates SHOULD be used.
 * A Signed Statement MUST include a JSON web signature (JWS) as defined here:
 http://tools.ietf.org/html/draft-ietf-jose-json-web-signature, as an attachment with a usageType
 of "http://adlnet.gov/expapi/attachments/signature" and a contentType of "application/octet-stream".
-* The JWS signature MUST have a payload of a valid JSON serialization of the full Statement, minus signature.
+* The JWS signature MUST have a payload of a valid JSON serialization of the complete Statement, minus signature.
 * The JWS signature MUST use an algorithm of "RS256","RS384", or "RS512".
 * The JWS signature SHOULD have been created based on the private key associated with an
 X.509 certificate.

--- a/xAPI.md
+++ b/xAPI.md
@@ -1195,6 +1195,8 @@ Run-Time Environment. See [Appendix C](#AppendixC) for examples of each format.
 	<tr>
 		<td>numeric</td>
 		<td>A range of numbers represented by a minimum and a maximum delimited by <code>[:]</code>. 
+			Where the range does not have a maximum or does not have a minimum, that number is omitted but the delimiter is
+			still used. E.g. ```"[:]4"``` indicates a maximum for 4 and no minimum. 
 			Where the correct response or learner's response is a single number rather than a range, the single number
 			with no delimiter MAY be used. 
 		</td>

--- a/xAPI.md
+++ b/xAPI.md
@@ -2318,8 +2318,7 @@ for discoverability of the signer X.509 certificates SHOULD be used.
 * A Signed Statement MUST include a JSON web signature (JWS) as defined here:
 http://tools.ietf.org/html/draft-ietf-jose-json-web-signature, as an attachment with a usageType
 of "http://adlnet.gov/expapi/attachments/signature" and a contentType of "application/octet-stream".
-* The JWS signature MUST have a payload of a valid JSON serialization of the Statement generated
-before the signature was added.
+* The JWS signature MUST have a payload of a valid JSON serialization of the full Statement, minus signature.
 * The JWS signature MUST use an algorithm of "RS256","RS384", or "RS512".
 * The JWS signature SHOULD have been created based on the private key associated with an
 X.509 certificate.

--- a/xAPI.md
+++ b/xAPI.md
@@ -3177,17 +3177,17 @@ Returns: ```200 OK```, Statement or [Statement Result](#retstmts) (See [Section 
 	</tr>
 	<tr>
 		<td>format</td>
-		<td>String: (```ids```, ```exact```, or ```canonical```)</td>
+		<td>String: ("ids", "exact", or "canonical")</td>
 		<td>exact</td>
-		<td>If ```ids```, only include minimum information necessary in Agent, Activity, Verb 
+		<td>If "ids", only include minimum information necessary in Agent, Activity, Verb 
 			and Group Objects to identify them. For anonymous groups this means including 
 			the minimum information needed to identify each member. 
 			<br/><br/>
-			If ```exact```, return Agent, Activity, Verb and Group Objects populated exactly as they 
+			If "exact", return Agent, Activity, Verb and Group Objects populated exactly as they 
 			were when the Statement was received. An LRS requesting Statements for the purpose 
 			of importing them would use a format of ```exact```.  
 			<br/><br/>
-			If ```canonical```, return Activity Objects and Verbs populated with the canonical
+			If "canonical", return Activity Objects and Verbs populated with the canonical
 			definition of the Activity Objects and Display of the Verbs as determined by the LRS, after
 			applying the <a href="#queryLangFiltering">language filtering process defined below</a>,
 			and return the original Agent and Group Objects as in ```exact``` mode.  
@@ -3196,8 +3196,8 @@ Returns: ```200 OK```, Statement or [Statement Result](#retstmts) (See [Section 
 	</tr>
 	<tr>
 		<td>attachments</td><td>Boolean</td><td>false</td>
-		<td>If ```true```, the LRS uses the multipart response format and includes all attachments as 
-		described previously.  If ```false```, the LRS sends the prescribed response with Content-Type 
+		<td>If "true", the LRS uses the multipart response format and includes all attachments as 
+		described previously.  If "false", the LRS sends the prescribed response with Content-Type 
 		application/json and cannot use attachments.</td>
 		<td>Optional</td>
 	</tr>
@@ -3205,7 +3205,7 @@ Returns: ```200 OK```, Statement or [Statement Result](#retstmts) (See [Section 
 		<td>ascending</td>
 		<td>Boolean</td>
 		<td>false</td>
-		<td>If ```true```, return results in ascending order of stored time</td>
+		<td>If "true", return results in ascending order of stored time</td>
 		<td>Optional</td>
 	</tr>
 </table>

--- a/xAPI.md
+++ b/xAPI.md
@@ -68,7 +68,7 @@
     *	7.6.	[Activity Profile API](#actprofapi)  
     *	7.7.	[Agent Profile API](#agentprofapi)  
     *	7.8.	[About resource](#aboutresource)  
-    *	7.9.	[Cross Origin Requests](#cors)  
+    *	7.9.	[Alternate Request Syntax](#alt-request-syntax)  
     *	7.10.	[Validation](#validation)  
     *	7.11.	[HTTP HEAD](#httphead)  
 *	[Appendix A: Example Statements](#AppendixA)  
@@ -3095,10 +3095,11 @@ do not match.
 * The LRS MAY respond before Statements that have been stored are available for retrieval.
 
 * GET Statements MAY be called using POST and form parameters if necessary as query strings 
-have limits. See Section [7.9 Cross Origin Requests](#79-cross-origin-requests) for more details.
+
+have limits. See Section [7.9 Alternate Request Syntax](#alt-request-syntax) for more details.
 
 * The LRS MUST differentiate a POST to add a Statement or to list Statements based on the 
-parameters passed. See Section [7.9 Cross Origin Requests](#79-cross-origin-requests) for more details.
+parameters passed. See Section [7.9 Alternate Request Syntax](#alt-request-syntax) for more details.
 
 <a name="stmtapiget"/>
 
@@ -3894,9 +3895,10 @@ property MUST occur only once.
 required by <a href="#apiversioning"/>6.2 API Versioning</a>.
 
 
-<a name="cors"/>
+<a name="alt-request-syntax"/>
 
-### 7.9 Cross Origin Requests
+### 7.9 Alternate Request Syntax
+
 
 ###### Description
 
@@ -3949,9 +3951,8 @@ MUST instead be included as a form parameter with the same name.
 * The LRS MUST treat any form parameters other than "content" or the 
 header parameters listed above as query string parameters. 
 
-__Attachments__: Sending attachment data requires sending a
-multipart/mixed request, therefore sending attachment data is not supported
-with this syntax. See [4.1.11. Attachments](#attachments) 
+__Attachments__: Note that due to issues relating to encoding, it is not possible to send 
+binary data attachments using this syntax. See [4.1.11. Attachments](#attachments) 
 
 * The LRS MUST support the syntax above.
 
@@ -5011,7 +5012,7 @@ attachment message format.
 
 ## Appendix G: Cross Domain Request example
 
-Section [7.9 Cross Origin Requests](#79-cross-origin-requests) outlines alternative syntax for use 
+Section [7.9 Alternate Request Syntax](#alt-request-syntax) outlines alternative syntax for use 
 when the normal syntax cannot be used due to browser or querystring length restrictions. This appendix provides an example of a
 PUT statements request following this format. 
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -3463,7 +3463,7 @@ the resulting document stored in the LRS is:
 
 ###### Requirements
 
-* If the document being posted or any existing document do not have a Content-Type
+* If the document being posted or any existing document does not have a Content-Type
 of "application/json", or if either document cannot be parsed as a JSON Object, the LRS MUST
 respond with HTTP status code ```400 Bad Request```, and MUST NOT update the target document
 as a result of the request.

--- a/xAPI.md
+++ b/xAPI.md
@@ -438,8 +438,13 @@ specification. A system that fails to implement a MUST (or a MUST NOT) requireme
 Failing to meet a SHOULD requirement is not a violation of conformity, but goes against best practices. 
 MAY indicates an option, to be decided by the developer with no consequences for conformity.
 
-The use of an asterisk* following SHOULD indicates a very strong recommendation. It is likely that
-these recommendations will become MUST requirements in a future version. 
+The use of an asterisk* following SHOULD indicates a very strong recommendation. It is planned that these 
+recommendations will become MUST requirements in a future version. Not following these recommendations could 
+risk interoperability and and/or lead to various other issues depending on the specifics of the recommendation. 
+Whilst these recommendations cannot be MUST requirements within this version (as these would be breaking changes) 
+the xAPI Working Group strongly encourages adopters to implement these requirements as though they were MUST requirements, 
+whilst continuing to support other adopters that might not do so.
+
 
 <a name="def-profile" />
 


### PR DESCRIPTION
Fixes #565. 

This involved bumping the numbers in the contents list, so I tidied up some whitespace there at the same time. 

This one likely needs discussion as we didn't reach consensus in the issue. 