### PR TITLE
Explicitly state sha2 is always always required for attachments.

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -1943,7 +1943,7 @@ The table below lists all properties of the Attachment object.
 	<tr>
 		<td>sha2</td>
 		<td>String</td>
-		<td>The SHA-2 (SHA-256, SHA-384, SHA-512) hash of the attachment data. <br/>
+		<td>The SHA-2 hash of the attachment data. <br/>
 		This property is always required, even if "fileURL" is also specified. 
 		</td>
 		<td>Required</td>
@@ -2020,7 +2020,7 @@ contain attachments.
 * The Client MAY send multiple Statements where some or all have attachments if using "POST".
 * The Client MAY send batches of type "application/json" where every attachment
 Object has a fileUrl, ignoring all requirements based on the "multipart/mixed" format.
-* The Client SHOULD NOT use SHA-224 to populate the "sha2" property: a minimum key size of 256 bits is recommended.
+* The Client SHOULD use SHA-256, SHA-384, or SHA-512  to populate the "sha2" property.
 
 
 ###### Example

--- a/xAPI.md
+++ b/xAPI.md
@@ -1943,8 +1943,7 @@ The table below lists all properties of the Attachment object.
 	<tr>
 		<td>sha2</td>
 		<td>String</td>
-		<td>The SHA-2 (SHA-256, SHA-384, SHA-512) hash of the attachment data. SHA-224 
-		SHOULD not be used: a minimum key size of 256 bits is recommended.<br/>
+		<td>The SHA-2 (SHA-256, SHA-384, SHA-512) hash of the attachment data. <br/>
 		This property is always required, even if "fileURL" is also specified. 
 		</td>
 		<td>Required</td>
@@ -2021,6 +2020,7 @@ contain attachments.
 * The Client MAY send multiple Statements where some or all have attachments if using "POST".
 * The Client MAY send batches of type "application/json" where every attachment
 Object has a fileUrl, ignoring all requirements based on the "multipart/mixed" format.
+* The Client SHOULD NOT use SHA-224 to populate the "sha2" property: a minimum key size of 256 bits is recommended.
 
 
 ###### Example

--- a/xAPI.md
+++ b/xAPI.md
@@ -1944,7 +1944,9 @@ The table below lists all properties of the Attachment object.
 		<td>sha2</td>
 		<td>String</td>
 		<td>The SHA-2 (SHA-256, SHA-384, SHA-512) hash of the attachment data. SHA-224 
-		SHOULD not be used: a minimum key size of 256 bits is recommended.</td>
+		SHOULD not be used: a minimum key size of 256 bits is recommended.<br/>
+		This property is always required, even if "fileURL" is also specified. 
+		</td>
 		<td>Required</td>
 		<td>X-Experience-API-Hash</td>
 	</tr>


### PR DESCRIPTION
Fixes #557 

My honest view on this though is that this PR isn't required and that the issue can simply be closed. The fact that sha2 is listed as required and fileUrl is listed as optional is pretty clear to me that sha2 is always required. 

Now we have a PR, hopefully the issue can be closed either way!