### PR TITLE
remove all reference to reporting systems/tools

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -2859,7 +2859,7 @@ parameters, not in the OAuth header.
 
 ##### Example
 The list of scopes determines the set of permissions that is being requested. 
-For example,an instructor might grant "statements/read" to a client, 
+For example,an instructor might grant "statements/read" to a Client, 
 but the LRS would still limit that tool to Statements that the instructor could 
 read if querying the LRS with their credentials directly (such as Statements 
 relating to their students).
@@ -3423,7 +3423,7 @@ which language entry to include, rather than to the resource (list of Statements
 desribes how voided statements are handled by the LRS when queried. 
 
 Clients can identify the presence and statementId of any voided Statements by the target of the voiding Statement. 
-Aside from debugging tools, many clients will not want to display voiding statements to their
+Aside from debugging tools, many Clients will not want to display voiding statements to their
 users and will not display these as part of activity streams and other reports. 
 
 ###### Requirements

--- a/xAPI.md
+++ b/xAPI.md
@@ -148,7 +148,7 @@ which are the means by which experiences are conveyed by an Activity Provider.
 * Data Transfer methods for the storage and retrieval (but not validation) of
 these Objects to/from a Learning Record Store.  Note that the systems storing 
 or retrieving records need not be Activity Providers. LRSs can 
-communicate with other LRSs, or reporting systems.
+communicate with other LRSs, or systems.
 
 * Security methods allowing for the trusted exchange of information between
 the Learning Record Store and trusted sources.  
@@ -361,8 +361,8 @@ __Base Endpoint__: The maximal path under all Experience API endpoints, includin
 
 <a name="def-client" />
 
-__Client__: - Refers to any entity that might interact with an LRS. A Client can be an 
-Activity Provider, reporting tool, an LMS, or another LRS.
+__Client__: - Refers to any entity that might interact with an LRS. A Client can be (for example) an 
+Activity Provider, an LMS, or another LRS.
 
 <a name="def-community-of-practice" />
 
@@ -1668,8 +1668,8 @@ The following table contains the properties of the Context Object.
 * The revision property SHOULD NOT be used if there is a major change in learning objectives, pedagogy, 
 or assets of an Activity. (Use a new Activity id instead).
 
-__Note:__ Revision has no behavioral implications within the scope of xAPI. It is simply stored,
-so that it is available for reporting tools.
+__Note:__ Revision has no behavioral implications within the scope of xAPI. It is simply stored
+so that it is available for systems interpreting and displaying data.
 
 <a name="Registration"/>
 
@@ -2267,7 +2267,6 @@ Object of that voiding Statement not being present.
 definitions which were introduced by the Statement that was just voided.
 * An Activity Provider that wants to "unvoid" a previously voided Statement SHOULD issue that Statement 
 again under a new id.
-* A reporting system SHOULD NOT show voided or voiding Statements by default.
 
 __Note:__ See ["Statement References"](#stmtref) in [Section 4.1.4.3 When the "Object" is a Statement](#stmtasobj) 
 for details about making references to other Statements.  To see how voided statements behave when queried, 
@@ -2860,7 +2859,7 @@ parameters, not in the OAuth header.
 
 ##### Example
 The list of scopes determines the set of permissions that is being requested. 
-For example,an instructor might grant "statements/read" to a reporting tool, 
+For example,an instructor might grant "statements/read" to a client, 
 but the LRS would still limit that tool to Statements that the instructor could 
 read if querying the LRS with their credentials directly (such as Statements 
 relating to their students).
@@ -2885,6 +2884,12 @@ This section describes that the xAPI consists of 4 sub-APIs: Statement, State,
 Agent, and Activity Profile. These four sub-APIs of the Experience API are 
 handled via RESTful HTTP methods. The Statement API can be used by itself to 
 track learning records. 
+
+An LRS will support all of the endpoints described in this section. It's also possible
+for a tool which is not an LRS to choose to follow the LRS requirements of one or 
+more of the endpoints and methods described in this section. For example a tool might
+implement POST Statements for the purposes of receiving incoming Statements forwarded by an LRS.
+Such a system is not considered to be an LRS or 'partial LRS'; it is simply not an LRS. 
 
 __Note:__ In all of the example endpoints given in the specification, 
 "http://example.com/xAPI/" is the example base endpoint of the LRS. All other IRI 
@@ -3414,22 +3419,24 @@ which language entry to include, rather than to the resource (list of Statements
 <a name="voidedStatements" />
 
 ####7.3.4 Voided Statements
+[Section 4.3 Voided](#voided) describes the process by which statements can be voided. This section
+desribes how voided statements are handled by the LRS when querried. 
+
+Clients can identify the presence and statementId of any voided Statements by the target of the voiding Statement. 
+Aside from debugging tools, many clients will not want to display voiding statements to their
+users and will not display these as part of activity streams and other reports. 
 
 ###### Requirements
 
 * The LRS MUST not return any Statement which has been voided, unless that Statement has been
 requested by voidedStatementId. The process described in
 [the section on filter conditions for StatementRefs](#queryStatementRef) is no exception to this
-requirement.
+requirement. Clients wishing to retrieve voided Statements request these individually by voidedStatementId.
 
 * The LRS MUST still return any Statements targeting the voided 
 Statement, following the process and conditions described in
 [the section on filter conditions for StatementRefs](#queryStatementRef). This includes the
-voiding Statement, which cannot be voided. Reporting tools can identify the presence and
-statementId of any voided Statements by the target of the voiding Statement. 
-
-* Reporting tools wishing to retrieve voided Statements SHOULD request these individually by 
-voidedStatementId.
+voiding Statement, which cannot be voided. 
 
 <a name="docapis" />
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -3420,7 +3420,7 @@ which language entry to include, rather than to the resource (list of Statements
 
 ####7.3.4 Voided Statements
 [Section 4.3 Voided](#voided) describes the process by which statements can be voided. This section
-desribes how voided statements are handled by the LRS when querried. 
+desribes how voided statements are handled by the LRS when queried. 
 
 Clients can identify the presence and statementId of any voided Statements by the target of the voiding Statement. 
 Aside from debugging tools, many clients will not want to display voiding statements to their


### PR DESCRIPTION
* Fixes #638 via a different approach than #662 

* Explicitly states that non-LRS systems can implement one or more LRS endpoints/methods and gives an example. Clarifies that systems which do so are not LRSs. I added this in this PR because I was starting to go down this route in the definition of reporting systems and felt it didn't belong in a definition.