### PR TITLE
Callout the Concurrency Requirements for State APIs

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -3022,7 +3022,7 @@ The semantics of the call are driven by the stateId parameter. If it is included
 the GET and DELETE methods will act upon a single defined state document 
 identified by "stateId". Otherwise, GET will return the available ids, and DELETE 
 will delete all state in the context given through the other parameters. This API has 
-[Concurrency](#concurrency) requirements which must be met.
+recommended [Concurrency](#concurrency) controls associated with it.
 
 ###### Single Document (PUT | POST | GET | DELETE)
 Example endpoint: http://example.com/xAPI/activities/state
@@ -3141,8 +3141,8 @@ The Activity Profile API is much like the State API, allowing for arbitrary key
 
 The semantics of the call are driven by the profileId parameter. If it is included, 
 the GET method will act upon a single defined document identified by "profileId". 
-Otherwise, GET will return the available ids. This API has [Concurrency](#concurrency) 
-requirements which must be met.
+Otherwise, GET will return the available ids. This API has required [Concurrency](#concurrency) 
+controls associated with it.
 
 The Activity Profile API also includes a method to retrieve a full description 
 of an Activity from the LRS.  
@@ -3229,7 +3229,8 @@ Otherwise, GET will return the available ids.
 
 The Agent Profile API also includes a method to retrieve a special Object with 
 combined information about an Agent derived from an outside service, such as a 
-directory service. This API has [Concurrency](#concurrency) requirements which must be met.
+directory service. This API has required [Concurrency](#concurrency) controls 
+associated with it.
 
 ###### Combined Information GET 
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -3021,7 +3021,8 @@ own internal storage, or need to persist state across devices.
 The semantics of the call are driven by the stateId parameter. If it is included, 
 the GET and DELETE methods will act upon a single defined state document 
 identified by "stateId". Otherwise, GET will return the available ids, and DELETE 
-will delete all state in the context given through the other parameters.  
+will delete all state in the context given through the other parameters. This API has 
+[Concurrency](#concurrency) requirements which must be met.
 
 ###### Single Document (PUT | POST | GET | DELETE)
 Example endpoint: http://example.com/xAPI/activities/state
@@ -3140,7 +3141,8 @@ The Activity Profile API is much like the State API, allowing for arbitrary key
 
 The semantics of the call are driven by the profileId parameter. If it is included, 
 the GET method will act upon a single defined document identified by "profileId". 
-Otherwise, GET will return the available ids.
+Otherwise, GET will return the available ids. This API has [Concurrency](#concurrency) 
+requirements which must be met.
 
 The Activity Profile API also includes a method to retrieve a full description 
 of an Activity from the LRS.  
@@ -3227,7 +3229,7 @@ Otherwise, GET will return the available ids.
 
 The Agent Profile API also includes a method to retrieve a special Object with 
 combined information about an Agent derived from an outside service, such as a 
-directory service.  
+directory service. This API has [Concurrency](#concurrency) requirements which must be met.
 
 ###### Combined Information GET 
 


### PR DESCRIPTION
When I was going through the specification it was completely unclear to me that the State APIs have concurrency requirements associated with them. It wasn't until I was going to put in an issue to talk about adding the feature that I noticed the mention in the Concurrency section.

All that I did was simply callout in the State API section that there are requirements for each of the State APIs that must be met for concurrency that way it is more clear that there's more to the State APIs than just what is listed there.