### PR TITLE
Call Out Concurrency Controls for Document APIs

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -3509,8 +3509,8 @@ own internal storage, or need to persist state across devices.
 The semantics of the call are driven by the stateId parameter. If it is included, 
 the GET and DELETE methods will act upon a single defined state document 
 identified by "stateId". Otherwise, GET will return the available ids, and DELETE 
-will delete all state in the context given through the other parameters. This API has 
-recommended [Concurrency](#concurrency) controls associated with it.
+will delete all state in the context given through the other parameters. This API has
+[Concurrency](#concurrency) controls associated with it.
 
 ###### Single Document (PUT | POST | GET | DELETE)
 Example endpoint: http://example.com/xAPI/activities/state
@@ -3640,8 +3640,8 @@ the GET method will act upon a single defined document identified by "profileId"
 Otherwise, GET will return the available ids.
 
 The Activity Profile API also includes a method to retrieve a full description 
-of an Activity from the LRS. This API has required [Concurrency](#concurrency) 
-controls associated with it.
+of an Activity from the LRS. This API has [Concurrency](#concurrency) controls 
+associated with it.
 
 ###### Full Activity Object GET
 Example endpoint: http://example.com/xAPI/activities
@@ -3733,8 +3733,8 @@ Otherwise, GET will return the available ids.
 
 The Agent Profile API also includes a method to retrieve a special Object with 
 combined information about an Agent derived from an outside service, such as a 
-directory service. This API has required [Concurrency](#concurrency) 
-controls associated with it.
+directory service. This API has [Concurrency](#concurrency) controls associated 
+with it.
 
 ###### Combined Information GET 
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -3509,7 +3509,8 @@ own internal storage, or need to persist state across devices.
 The semantics of the call are driven by the stateId parameter. If it is included, 
 the GET and DELETE methods will act upon a single defined state document 
 identified by "stateId". Otherwise, GET will return the available ids, and DELETE 
-will delete all state in the context given through the other parameters.  
+will delete all state in the context given through the other parameters. This API has 
+recommended [Concurrency](#concurrency) controls associated with it.
 
 ###### Single Document (PUT | POST | GET | DELETE)
 Example endpoint: http://example.com/xAPI/activities/state
@@ -3639,7 +3640,8 @@ the GET method will act upon a single defined document identified by "profileId"
 Otherwise, GET will return the available ids.
 
 The Activity Profile API also includes a method to retrieve a full description 
-of an Activity from the LRS.  
+of an Activity from the LRS. This API has required [Concurrency](#concurrency) 
+controls associated with it.
 
 ###### Full Activity Object GET
 Example endpoint: http://example.com/xAPI/activities
@@ -3731,7 +3733,8 @@ Otherwise, GET will return the available ids.
 
 The Agent Profile API also includes a method to retrieve a special Object with 
 combined information about an Agent derived from an outside service, such as a 
-directory service.  
+directory service. This API has required [Concurrency](#concurrency) 
+controls associated with it.
 
 ###### Combined Information GET 
 


### PR DESCRIPTION
This PR is a rebase of #681 which was based on `master` and a PR to `master`. This one bases off `1.0.3` and adds similar content with some clarification based on feedback.

Here's the original PR text:
> When I was going through the specification it was completely unclear to me that the State APIs have concurrency requirements associated with them. It wasn't until I was going to put in an issue to talk about adding the feature that I noticed the mention in the Concurrency section.

> All that I did was simply callout in the State API section that there are requirements for each of the State APIs that must be met for concurrency that way it is more clear that there's more to the State APIs than just what is listed there.