### PR TITLE
Part1 section8

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -533,17 +533,21 @@ begin with /extensions and that LRSs create other custom xAPI Resources there.
 
 A profile of xAPI is a set of rules and/or vocabularies applied to a valid xAPI implementation.  Often, a CoP leverages many best practices to create a profile.
 
-A profile will typically define some of the open-ended areas of the specification, such as identifying verbs, activity types, structure and domains for IRIs, and names/possible values within xAPI Resources like the State API.
+A profile will typically define some of the open-ended areas of the specification, such as identifying verbs, activity types, structure and domains for IRIs, and names/possible values within xAPI Resources like the State API.  This is 
+referred to as creating a vocabulary.
 
 It is recommended that a profile use a unique "category" within a Statement's context to refer to any Statement  
-which follows the profile.
+which follows the profile.  An example profile is <a href="https://github.com/AICC/CMI-5_Spec_Current/tree/sandstone-release"> cmi5 </a>, which fits the 
+traditional single learner, single online learning use case.
 
-xAPI Communities of Practice are groups of people that have common goals for tracking a certain domain that can utilize xAPI.  A CoP typically already has a certain taxonomy to it, methodologies, and values.  xAPI CoPs 
-can define their own Verbs, Activity types, extensions, and other parts of Statements and Resources to align with 
-their group's needs.  
+xAPI Communities of Practice are groups that have common goals for tracking a certain domain that can utilize xAPI.  
+A CoP typically already has a certain vocabulary used, processes, and values.  xAPI CoPs can define their own verbs,
+activity types, extensions, and other parts of statements and resources to align with their group's needs.  
 
 CoPs are highly recommended to avoid duplication of effort, as creating too many ways to solve the same problem 
-will cause fragmentation in similar domains and will hurt interoperability.
+will cause fragmentation in similar domains and will hurt interoperability.  An example of a CoP for the medical 
+field is the <a href="http://groups.medbiq.org/medbiq/display/XIG/XAPI+Interest+Group+Home">Medbiquitous xAPI Interest 
+Group </a>.
 
 The text below will be expanded to include all "coined" parts
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -507,49 +507,39 @@ __Verb__: Defines the action being done by the Actor within the Activity within 
 
 ## 7.0 xAPI Components
 
-## 8.0 Getting More Out of xAPI
 
-xAPI focuses on the structure of communication between a client and an LRS.  It spares many details of the content to
-increase flexibility.  The intention in only supplying a basic amount of syntax rules is that Communities of Practice (CoP) can define content (verbs, activity types, contextual relationships, extensions, etc.) for their use cases.  It is very 
-important that such communities exist and share best practices.
 
-### 8.1 Extending xAPI
+## 8.0 Extending xAPI
 
-xAPI can be extended in a few ways.  The most notable and extensive is Statement Extensions, which allow great flexibility 
-within Statements.  It is recommended that profiles or Communities or Practice agree on how to use extensions for their 
-particular use cases. Implementation details are covered in a <a href="#miscext">later section</a>.  
+xAPI can be extended in a few ways.  The most notable and extensive is Statement Extensions, which allow great flexibility within Statements.  It is recommended that profiles or Communities or Practice agree on how to use  
+extensions for their particular use cases. Implementation details are covered in a [later section](#miscext)
 
-The About Resource is another way xAPI enables extensions.  The LRS may find it useful to communicate features or 
-behaviors beyond this specification to activity provider.  It is hoped that if more information is available about an 
-LRS, that the About Resource captures it.
+The About Resource is another place xAPI supports Extensions.  The LRS may find it useful to communicate features or behaviors beyond this specification to activity provider.  It is hoped that if more information is available about an LRS, that the About Resource contains it.
 
-Finally, the set of Resources implemented is not expected to be constrained by this document. While not explicitly 
-defined, this document suggests that no new Endpoints defined in future iterations of this specification will 
-begin with /extensions and that LRSs create other custom xAPI Resources there. 
+Finally, the set of Resources implemented is not expected to be constrained by this document. Resources beyond 
+those listed in this specification can be implemented and co-exist with current Resources.
 
 <a name="COPs" />
 
-### 8.2 Profiles and Communities of Practice
+## 9.0 Profiles and Communities of Practice
+
+xAPI focuses on the structure of communication between a client and an LRS.  It spares many details of the content 
+to increase flexibility.  The intention in keeping the specification somewhat loose is that Communities of  
+Practice (CoP) can define content (verbs, activity types, contextual relationships, extensions, etc.) for their use cases.  It is very important that such communities exist and share best practices.
 
 A profile of xAPI is a set of rules and/or vocabularies applied to a valid xAPI implementation.  Often, a CoP leverages many best practices to create a profile.
 
-A profile will typically define some of the open-ended areas of the specification, such as identifying verbs, activity types, structure and domains for IRIs, and names/possible values within xAPI Resources like the State API.  This is 
-referred to as creating a vocabulary.
+A profile will typically describe in greater detail some of the open-ended areas of the specification, such as 
+verbs, activity types, attachment usage, extensions, structure and domains for IRIs, and keys/possible values 
+within xAPI Resources like the State API.  This is referred to as creating a vocabulary.
 
 It is recommended that a profile use a unique "category" within a Statement's context to refer to any Statement  
-which follows the profile.  An example profile is <a href="https://github.com/AICC/CMI-5_Spec_Current/tree/sandstone-release"> cmi5 </a>, which fits the 
-traditional single learner, single online learning use case.
-
-xAPI Communities of Practice are groups that have common goals for tracking a certain domain that can utilize xAPI.  
-A CoP typically already has a certain vocabulary used, processes, and values.  xAPI CoPs can define their own verbs,
-activity types, extensions, and other parts of statements and resources to align with their group's needs.  
+which follows the profile.  An example profile is [cmi5](https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_runtime.md#ContextActivities"), which is designed for the traditional single learner, single online learning use case.
 
 CoPs are highly recommended to avoid duplication of effort, as creating too many ways to solve the same problem 
 will cause fragmentation in similar domains and will hurt interoperability.  An example of a CoP for the medical 
-field is the <a href="http://groups.medbiq.org/medbiq/display/XIG/XAPI+Interest+Group+Home">Medbiquitous xAPI Interest 
-Group </a>.
+field is the [Medbiquitous xAPI Interest Group](http://groups.medbiq.org/medbiq/display/XIG/XAPI+Interest+Group+Home).
 
-The text below will be expanded to include all "coined" parts
 
 ##### Use in Communities of Practice
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -509,11 +509,55 @@ __Verb__: Defines the action being done by the Actor within the Activity within 
 
 ## 8.0 Getting More Out of xAPI
 
+xAPI was developed to be as lightweight as possible, but able to be focused to be powerful.  xAPI defines only 
+one verb (for voiding Statements) and only one activity type (cmi.interaction).  Obviously, this isn't meant to 
+be the extent of what xAPI can do.  xAPI is limitless in how far it can be taken, which is why this document 
+doesn't attempt to define a "starting set", because it would encourage adoption of only said set.  Many of the 
+Resources, such as State and Activity Profile, are intentionally left as "a set of name/value" pairs to not try 
+to force a certain practice.  The very notion of IRIs and suggested resolvable metadata be at the location is a 
+way to continuously increase the value of xAPI by not tying definitions down permanently.  
+
 ### 8.1 Extending xAPI
+
+xAPI can be extended in a few ways.  The most notable is Statement Extensions, which are covered in a 
+<a href="#miscext">later section</a>.  Extending Statements is how new types of information are brought into a 
+Statement and can only be done in three places.  
+
+The About Resource is another way xAPI enables extensions.  Of the Resources (located at various Endpoints), the  
+only one that can be extended is the About Resource.  It is hoped that if more information is available about an  
+LRS, that the About Resource captures it.
+
+Finally, the set of Resources implemented is not expected to be constrained by this document. While not explicitly 
+defined, this document suggests that no new Endpoints defined in future iterations of this specification will 
+begin with /extensions and that LRSs create other custom xAPI Resources there. 
 
 ### 8.2 Profiles
 
+Profile in this specification usually refers to the Activity Profile or Agent Profile, which are useful Resources, 
+each having their own Endpoint.  These profiles, while useful, are not very defined.  Another use of profile in 
+xAPI is applying a set of rules and/or vocabularies consistently.  An xAPI Profile follows all rules (MUSTs) of 
+the specification, but can more narrowly define xAPI requirements or create its own.  
+
+A profile will typically define some of the open-ended areas of the specification, such as identifying verbs, activity types, structure and domains for IRIs, and names/possible values within xAPI Resources like the State API.
+
+The implementation details of profile are typically best practices as defined by one or more <a href="COPs">Communities of Practice</a>
+
+
+It is recommended that a profile use a unique "category" within a Statement's context to refer to any Statement  
+which follows the profile.
+
+<a name="COPs" />
+
 ### 8.3 Communities of Practice
+
+xAPI Communities of Practice (CoP)s are groups of people that have common goals for tracking a certain domain that can utilize xAPI.  A CoP typically already has a certain taxonomy to it, methodologies, and values.  xAPI CoPs 
+can define their own Verbs, Activity types, extensions, and other parts of Statements and Resources to align with 
+their group's needs.  
+
+CoPs are highly recommended to avoid duplication of effort, as creating too many ways to solve the same problem 
+will cause fragmentation in similar domains and will hurt interoperability.
+
+The text below will be expanded to include all "coined" parts
 
 ##### Use in Communities of Practice
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -509,48 +509,36 @@ __Verb__: Defines the action being done by the Actor within the Activity within 
 
 ## 8.0 Getting More Out of xAPI
 
-xAPI was developed to be as lightweight as possible, but able to be focused to be powerful.  xAPI defines only 
-one verb (for voiding Statements) and only one activity type (cmi.interaction).  Obviously, this isn't meant to 
-be the extent of what xAPI can do.  xAPI is limitless in how far it can be taken, which is why this document 
-doesn't attempt to define a "starting set", because it would encourage adoption of only said set.  Many of the 
-Resources, such as State and Activity Profile, are intentionally left as "a set of name/value" pairs to not try 
-to force a certain practice.  The very notion of IRIs and suggested resolvable metadata be at the location is a 
-way to continuously increase the value of xAPI by not tying definitions down permanently.  
+xAPI focuses on the structure of communication between a client and an LRS.  It spares many details of the content to
+increase flexibility.  The intention in only supplying a basic amount of syntax rules is that Communities of Practice (CoP) can define content (verbs, activity types, contextual relationships, extensions, etc.) for their use cases.  It is very 
+important that such communities exist and share best practices.
 
 ### 8.1 Extending xAPI
 
-xAPI can be extended in a few ways.  The most notable is Statement Extensions, which are covered in a 
-<a href="#miscext">later section</a>.  Extending Statements is how new types of information are brought into a 
-Statement and can only be done in three places.  
+xAPI can be extended in a few ways.  The most notable and extensive is Statement Extensions, which allow great flexibility 
+within Statements.  It is recommended that profiles or Communities or Practice agree on how to use extensions for their 
+particular use cases. Implementation details are covered in a <a href="#miscext">later section</a>.  
 
-The About Resource is another way xAPI enables extensions.  Of the Resources (located at various Endpoints), the  
-only one that can be extended is the About Resource.  It is hoped that if more information is available about an  
+The About Resource is another way xAPI enables extensions.  The LRS may find it useful to communicate features or 
+behaviors beyond this specification to activity provider.  It is hoped that if more information is available about an 
 LRS, that the About Resource captures it.
 
 Finally, the set of Resources implemented is not expected to be constrained by this document. While not explicitly 
 defined, this document suggests that no new Endpoints defined in future iterations of this specification will 
 begin with /extensions and that LRSs create other custom xAPI Resources there. 
 
-### 8.2 Profiles
+<a name="COPs" />
 
-Profile in this specification usually refers to the Activity Profile or Agent Profile, which are useful Resources, 
-each having their own Endpoint.  These profiles, while useful, are not very defined.  Another use of profile in 
-xAPI is applying a set of rules and/or vocabularies consistently.  An xAPI Profile follows all rules (MUSTs) of 
-the specification, but can more narrowly define xAPI requirements or create its own.  
+### 8.2 Profiles and Communities of Practice
+
+A profile of xAPI is a set of rules and/or vocabularies applied to a valid xAPI implementation.  Often, a CoP leverages many best practices to create a profile.
 
 A profile will typically define some of the open-ended areas of the specification, such as identifying verbs, activity types, structure and domains for IRIs, and names/possible values within xAPI Resources like the State API.
-
-The implementation details of profile are typically best practices as defined by one or more <a href="COPs">Communities of Practice</a>
-
 
 It is recommended that a profile use a unique "category" within a Statement's context to refer to any Statement  
 which follows the profile.
 
-<a name="COPs" />
-
-### 8.3 Communities of Practice
-
-xAPI Communities of Practice (CoP)s are groups of people that have common goals for tracking a certain domain that can utilize xAPI.  A CoP typically already has a certain taxonomy to it, methodologies, and values.  xAPI CoPs 
+xAPI Communities of Practice are groups of people that have common goals for tracking a certain domain that can utilize xAPI.  A CoP typically already has a certain taxonomy to it, methodologies, and values.  xAPI CoPs 
 can define their own Verbs, Activity types, extensions, and other parts of Statements and Resources to align with 
 their group's needs.  
 


### PR DESCRIPTION
Added some text to extending.  Likely we can eliminate text in a couple
other stray areas.    The text in the later portion of 8.3 should be
updated to refer to all "coinable" xAPI constructs.