### PR TITLE
Interaction type should be required

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -1432,7 +1432,7 @@ The table below lists the properties for Interaction Activities.
 		<td>String</td>
 		<td>The type of interaction. Possible values are: “true-false”, “choice”, “fill-in”, “long-fill-in”,
 		“matching”, “performance”, “sequencing”, “likert”, “numeric” or “other”. </td>
-		<td>Optional</td>
+		<td>Required</td>
 	</tr>
 	<tr>
 		<td>correctResponsesPattern</td>


### PR DESCRIPTION
These required/optional columns were added in 1.0.2. Since 1.0.0 and maybe before we have had the requirement ```Interaction Activities MUST have a valid interactionType.```. Therefore the "optional" in 1.0.2 is a typo and should be corrected in this version. 