### PR TITLE
Spell check. 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ This document outlines various ways of contributing to the specification:
 The most helpful **and** easiest way to contribute to the specification is to review an existing PR. You can find a 
 [list of open PRs here](https://github.com/adlnet/xAPI-Spec/pulls). To review a PR you should:
 
-* Read any issues linked to from the PR description and make sure you understand the issue the PR is desigend to address. 
+* Read any issues linked to from the PR description and make sure you understand the issue the PR is designed to address. 
 * Read any comments on both the issues and the PR to understand if the goals of the original issue have changed and if
 any solutions have been agreed. 
 * Read the relevant sections in the [development version](https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI.md) of the specification. 
@@ -141,21 +141,21 @@ the changes better. Check to see if what's been changed matches the solution you
 * Look for problems such as typos, unintended changes to behaviour and any text that's unclear. 
 * Check that anything that's been removed has either been replaced or the removal was intentional (based on reading the issue 
 and comments).
-* Check that the [Stle Guide](#style-guide) has been followed.
+* Check that the [Style Guide](#style-guide) has been followed.
 * If you spot any issues with the PR, add a comment describing these problems as best you can and suggesting how they can
 be resolved. 
 * If the PR looks good to you, add a comment saying "+1".
 * If you are unsure about the PR or have questions, ask questions in the PR comments. 
 * If you feel that the PR should never be merged, even with changes, add a comment starting with "-1" and explaining your
 reasons. If your comments run contrary to what's already been agreed in the issues, there might be some resistance, but that's ok
-if you have a strong arguement! 
+if you have a strong argument! 
 
 When reviewing a PR please don't:
 
 * Review and leave no comment; always let us know you've had a look!
 * Suggest additional changes outside of what the PR was intended to achieve. 
 [Raise a separate issue](https://github.com/adlnet/xAPI-Spec/issues/new) for additional changes. 
-* Make vague critisisms without suggesting the changes to the PR that would meet those critisisms. 
+* Make vague criticisms without suggesting the changes to the PR that would meet those criticisms. 
 
 <a name='suggest-solution'/>
 ### Suggest a solution
@@ -174,11 +174,11 @@ To suggest a solution to an issue you should:
 Once your suggestion has been discussed and agreed, add another comment summarising your understanding of the outcome of the discussion and
 including proposed wording for the changes you've suggested. 
 
-Good and detailed suggested solutions for issues maake it much easier to write PRa and helps to ensure those PRs are merged faster. 
+Good and detailed suggested solutions for issues make it much easier to write PRa and helps to ensure those PRs are merged faster. 
 
 <a name='make-pr'/>
 ### Make a Pull Request (PR)
-The hardest way of driectly contributing to the specification is to make Pull Requests and the xAPI Working Group recommends only getting involved in
+The hardest way of directly contributing to the specification is to make Pull Requests and the xAPI Working Group recommends only getting involved in
 this way if you are already used to Github and markdown and/or have previously contributed to reviewing PRs and suggesting solutions to issues. 
 
 Before making a PR you should:
@@ -195,7 +195,7 @@ When making a PR, you should include a description that explains:
 * What issue numbers of any issues you are addressing (normally just one issue)?
 * How does your PR relate to any proposed solutions to the issue?
 * If you have moved sections, have you made any changes to content within those moved sections?
-* What decisions did you make in writting the change? Why did you make those decisions? 
+* What decisions did you make in writing the change? Why did you make those decisions? 
 
 #### Edit on GitHub.com
 To edit the specification on GitHub.com, first open the [development version](https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI.md) 
@@ -248,7 +248,7 @@ gives you an option to clone it.
 
 ##### Add ADL repository as upstream remote
 Add a remote repository to git to reference the master repository. This will make 
-synchronizing with the master respository a bit easier.  
+synchronizing with the master repository a bit easier.  
 
 __Git__  
 ```git remote add upstream https://github.com/adlnet/xAPI-Spec```  
@@ -323,7 +323,7 @@ And
 
 ### Property and object names
 
-When refering to a property, parameter or object, but not specifically calling it out as property, parameter, or object 
+When referring to a property, parameter or object, but not specifically calling it out as property, parameter, or object 
 the name should be capitalized. No formatting or quotes should be used. 
 
 For example:
@@ -338,7 +338,7 @@ For example:
 
 And
 
-    The "member" property is an un-ordered list!
+    The "member" property is an unordered list!
 
 When a value is expected or described within plain text, but isn't specifically code, single quotes should be used.
 In situations where it is important to group text to be specific to the concept, single quotes should also be used.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 xAPI-Spec
 =========
 
-This Github repository contains the xAPI Specification. xAPI is a learning technologies interoperbility specification that describes communication 
+This Github repository contains the xAPI Specification. xAPI is a learning technologies interoperability specification that describes communication 
 about learner activity and experiences between technologies. You can [read the latest release of the specification here](xAPI.md).  The group meets the first, second, and third Wednesdays of each month on GoToWebinar.  You can register [at https://attendee.gotowebinar.com/register/279276321478091778](https://attendee.gotowebinar.com/register/279276321478091778)
 
 ## Specification versions
@@ -22,11 +22,11 @@ please give as much detail as you can in regards to:
 
 * Which part/parts of the specification you are reading.
 * Your understanding of what these parts mean.
-* The product and feature you are implmenting xAPI in; what's the use case you are trying to achieve?
+* The product and feature you are implementing xAPI in; what's the use case you are trying to achieve?
 * How you would like the specification to be improved. Suggest some specific new wording if you like!
 
 You'll need to [sign up for a GitHub account](https://github.com/signup/free) if you do not already have one in order
-to raise and comment on isues. 
+to raise and comment on issues. 
 
 You can discuss any issues before or after raising them on the [specification Google Group](https://groups.google.com/a/adlnet.gov/forum/#!forum/xapi-spec)
 and at our [weekly specification calls](https://attendee.gotowebinar.com/register/100000000063672381). 

--- a/xAPI.md
+++ b/xAPI.md
@@ -733,7 +733,7 @@ The details of each property of a statement are described in the table below.
 	<td>UUID assigned by LRS if not set by the Activity Provider.</td>
 	<td>Recommended</td></tr>
 	<tr><td><a href="#actor">actor</a></td><td>Object</td>
-	<td>Who the Statement is about, as an <a href="#agent">Agent</a> or 
+	<td>Whom the Statement is about, as an <a href="#agent">Agent</a> or 
 		<a href="#group">Group</a> Object. Represents the "I" in "I Did This".</td>
 	<td>Required</td></tr>
 	<tr><td><a href="#verb">verb</a></td><td>Object</td>
@@ -863,7 +863,7 @@ The table below lists all properties of an Anonymous Group.
 	<tr><td>objectType</td><td>String</td><td>"Group". </td><td>Required</td></tr>
 	<tr><td>name</td><td>String</td><td>Name of the group.</td><td>Optional</td></tr>
 	<tr><td>member</td><td>Array of <a href="#agent">Agent Objects</a></td>
-	<td>The members of this Group. This is an un-ordered list.</td>
+	<td>The members of this Group. This is an unordered list.</td>
 	<td>Required</td></tr>
 </table>
 
@@ -876,7 +876,7 @@ The table below lists all properties of an Identified Group.
 	<tr><td>objectType</td><td>String</td><td>"Group". </td><td>Required</td></tr>
 	<tr><td>name</td><td>String</td><td>Name of the group.</td><td>Optional</td></tr>
 	<tr><td>member</td><td>Array of <a href="#agent">Agent Objects</a></td>
-	<td>The members of this Group. This is an un-ordered list.</td>
+	<td>The members of this Group. This is an unordered list.</td>
 	<td>Optional</td></tr>
 	<tr><td colspan="2">see <a href="#inversefunctional"> 4.1.2.3 Inverse Functional Identifier</a></td>
 	    <td>An Inverse Functional Identifier unique to the Group.</td><td>Required</td></tr>	
@@ -1014,7 +1014,7 @@ The table below lists all properties of the Verb Object.
 		<td>The human readable representation of the 
 			Verb in one or more languages. This does not have any impact on the 
 			meaning of the Statement, but serves to give a human-readable 
-			display of the meaning already determined by the chosen Verb.</td>
+			display of the meaning already determined by the chosen Verb.</td>
 		<td>Recommended</td>
 	</tr>
 </table>
@@ -1039,7 +1039,7 @@ exactly as included (or omitted) within the Statement.
 * When queried for Statements with a Format of "canonical", the LRS SHOULD* return a canonical Display 
 for that Verb. 
 * The LRS may determine its canonical Display based on the Verb Display property included within 
-Statements it recieves, the Name property included in the metadata as described in 
+Statements it receives, the Name property included in the metadata as described in 
 [section 5.4 Identifier metadata](#miscmeta), or the Verb Display as defined in some other location.
 
 ###### Verb Display Client Requirements
@@ -1304,13 +1304,13 @@ See [Appendix C](#Appendix2C) for examples definitions for each interaction type
 		<td>fill-in</td>
 		<td>An interaction which requires the learner to supply a short response in the form of one or more 
 			strings of characters. Typically, the correct response consists of part of a word, one word or a few words. 
-			'Short' means that the corect responses pattern and learner response strings will normally be 250 characters or less;
+			'Short' means that the correct responses pattern and learner response strings will normally be 250 characters or less;
 		</td>
 	</tr>
 	<tr>
 		<td>long-fill-in</td>
 		<td>An interaction which requires the learner to supply a response in the form of a long string of characters.
-			'Long' means that the corect responses pattern and learner response strings will normally be more than 250 characters.
+			'Long' means that the correct responses pattern and learner response strings will normally be more than 250 characters.
 		</td>
 	</tr>
 	<tr>
@@ -1418,7 +1418,7 @@ Systems reading statements cannot infer success based on comparison of the Respo
 
 Where the Correct Response Pattern contains an empty array, the meaning of this is that there is no correct
 answer; all answers are incorrect. Where any answer is correct (e.g. in a survey), the Correct Response Pattern property
-is ommitted. 
+is omitted. 
 
 ###### Characterstring parameters
 Some of the values within the responses described above can be prepended with certain additional parameters. These were originally based on the characterstring
@@ -2230,7 +2230,7 @@ Object has a fileUrl, ignoring all requirements based on the "multipart/mixed" f
 ###### File URL
 The File URL is intended to provide a location from which the LRS or another system can retrieve the
 attachment. There are, however, no requirements for the owner of the attachment to make the 
-attachment data available at the location indefinately or to make the attachment publically
+attachment data available at the location indefinitely or to make the attachment publically
 available without security restrictions. When determining attachment hosting arrangements, 
 designers of systems that will send Statements using the "fileUrl" property are encouraged to 
 consider the needs of end recipient(s) of the Statement especially if the attachment content 
@@ -2542,7 +2542,7 @@ can make sense of it.
 ### 4.2 Language Maps
 
 ##### Description
-A language map is a dictionary where the key is a [RFC 5646 Language Tag](http://tools.ietf.org/html/rfc5646), and the value is a string in the language specified in the tag. This map SHOULD be populated as fully as possible based on the knowledge of the string in question in different languages.  
+A language map is a dictionary where the key is a [RFC 5646 Language Tag](http://tools.ietf.org/html/rfc5646), and the value is a string in the language specified in the tag. This map SHOULD be populated as fully as possible based on the knowledge of the string in question in different languages.  
 
 The content of strings within a language map is plain text. It's expected that any formatting code 
 such as HTML tags or markdown will not be rendered, but will be displayed as code when this string is 
@@ -2574,7 +2574,7 @@ Timestamps are a format type which represent a specific time.  They are formatte
 Statements sent to an LRS can be expected to keep precision to at least milliseconds 
 
 ###### Requirements
-* A Timestamp MUST be formatted according to [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations).
+* A Timestamp MUST be formatted according to [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations).
 * A Timestamp MUST preserve precision to at least milliseconds (3 decimal points beyond seconds).  
 * A Timestamp SHOULD* include the time zone.
 * If the Timestamp includes a time zone, the LRS MAY be return the Timestamp using a different timezone to the one 
@@ -2596,7 +2596,7 @@ section 4.4.3.3) MUST NOT be used.
 * Clients SHOULD provide a maximum precision of 0.01 seconds. 
 * Clients MAY provide less precision, for example in the case of reading a University Degree precision might 
 be in months or years. 
-* On receiving a Duration with more that 0.01 second precision, the LRS SHOULD* NOT reject the request but MAY 
+* On receiving a Duration with more than 0.01 second precision, the LRS SHOULD* NOT reject the request but MAY 
 truncate the Duration property to 0.01 second precision. 
 * When comparing Durations, any precision beyond 0.01 second precision SHOULD* NOT be included in the comparison.
 
@@ -2611,8 +2611,8 @@ The table below provides some example ISO 8601 durations. This list is not inten
 	</tr>
 	<tr>
 		<td>P16559.14S</td>
-		<td>The same time peroid as above represented in seconds. 
-		(Note: if the time peroid in question contained a leap second, this conversion would be inaccurate)</td>
+		<td>The same time period as above represented in seconds. 
+		(Note: if the time period in question contained a leap second, this conversion would be inaccurate)</td>
 	</tr>
 	<tr>
 		<td>P3Y1M29DT4H35M59.14S</td>
@@ -2624,7 +2624,7 @@ The table below provides some example ISO 8601 durations. This list is not inten
 	</tr>
 	<tr>
 		<td>P4W</td>
-		<td>Four weeks. Note that weeks cannot be combined with other time peroids. 'P4W1D' is not valid.</td>
+		<td>Four weeks. Note that weeks cannot be combined with other time periods. 'P4W1D' is not valid.</td>
 	</tr>
 </table>
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -3695,7 +3695,7 @@ is included in [Appendix B: Table of All Endpoints](#Appendix3B).
 described in [Section 6.4.2 OAuth Authorization Scope](#oauthscope).
 * The LRS MAY support additional endpoints not described in this specification. 
 * Past, current and future versions of this specification do not and will not define endpoints 
-with path segements starting 'extensions/'. LRSs supporting additional endpoints not defined 
+with path segments starting 'extensions/'. LRSs supporting additional endpoints not defined 
 in this specification SHOULD define those endpoints with path segments starting 'extensions/'.
 
 Sections 6 and 7 detail the more technical side of the Experience API, dealing with 
@@ -3715,7 +3715,7 @@ The basic communication mechanism of the Experience API.
 
 <a name="stmtresput"/>
 
-#####2.2.1.1 PUT Statements
+#####2.2.1.1 PUT Statements
 
 ###### Details
 
@@ -3754,7 +3754,7 @@ do not match. See [Statement comparision requirements](statement-comparision-req
 
 <a name="stmtrespost"/>
 
-#####2.2.1.2 POST Statements
+#####2.2.1.2 POST Statements
 
 ###### Details
 
@@ -3794,7 +3794,7 @@ parameters passed. See Section [7.9 Alternate Request Syntax](#alt-request-synta
 
 <a name="stmtresget"/>
 
-#####2.2.1.3 GET Statements
+#####2.2.1.3 GET Statements
 
 ###### Details
 
@@ -4043,13 +4043,13 @@ The LRS MUST return only one language in each of these maps.
 language maps. This includes the language map stored in the Verb Display property and potentially some 
 language maps used within extensions. 
 
-* If the LRS maintains a canonical version of a language map, it SHOULD* return this cannonical langauge map
+* If the LRS maintains a canonical version of a language map, it SHOULD* return this canonical language map
  when canonical format is used to retrieve Statements. 
 
 * The LRS SHOULD* return only one language within each language map for which it returns a canonical map. 
 
 * In order to choose the most relevant language, the LRS MUST apply the Accept-Language header as 
-described in <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html"> RFC 2616</a> 
+described in <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html"> RFC 2616</a> 
 (HTTP 1.1), except that this logic MUST be applied to each language map individually to select 
 which language entry to include, rather than to the resource (list of Statements) as a whole.
 
@@ -4057,7 +4057,7 @@ which language entry to include, rather than to the resource (list of Statements
 
 ##### 2.2.1.4 Voided Statements
 [Section 4.3 Voided](#voided) describes the process by which statements can be voided. This section
-desribes how voided statements are handled by the LRS when queried. 
+describes how voided statements are handled by the LRS when queried. 
 
 Clients can identify the presence and statementId of any voided Statements by the target of the voiding Statement. 
 Aside from debugging tools, many Clients will not want to display voiding statements to their
@@ -4829,7 +4829,7 @@ this specification.
 - [HTTP Basic Authentication](http://tools.ietf.org/html/rfc7235)
 - Common Access Cards
 
-Whislt Common Access Cards are defined as an authentication option within this specification,
+Whilst Common Access Cards are defined as an authentication option within this specification,
 the implementation details of this authentication method are not defined. The xAPI Working Group
 encourages LRS developers implementing Common Access Cards as an authentication method to collaborate
 in defining the details of this authentication method in a future version of this specification. 

--- a/xAPI.md
+++ b/xAPI.md
@@ -102,9 +102,9 @@
 <a name="introduction-partone"/>
 ## 1.0 Introduction
 
-The Experience API (xAPI) is a technical specification that aims to facilitate the documentation and communication of learning experiences. It does so by specifiing how learning experiences should be described and an Application Programming Interface that sets out how information about these experiences should be formatted and exchanged electronically.  
+The Experience API (xAPI) is a technical specification that aims to facilitate the documentation and communication of learning experiences. It does so by specifying how learning experiences should be described and an Application Programming Interface that sets out how information about these experiences should be formatted and exchanged electronically.  
 
-The xAPI is an initiative of the Advanced Distributed Learning (ADL), established in 1997 to standardize and modernize training and education management and delivery in the US. Among the many outcomes of this initiative was SCORM - the Shareable Content Object Reference Model. SCORM has become an internationally recongized framework that has been a major factor contributing to the economy and effectiveness of online learning around the world.
+The xAPI is an initiative of the Advanced Distributed Learning (ADL), established in 1997 to standardize and modernize training and education management and delivery in the US. Among the many outcomes of this initiative was SCORM - the Sharable Content Object Reference Model. SCORM has become an internationally recognized framework that has been a major factor contributing to the economy and effectiveness of online learning around the world.
   
 While SCORM has been a great success, there is a growing realization of the need to track learning experiences of individuals beyond formal, structured computer-based training. In assessing candidates' suitability for positions or their capability for performing various tasks, there is a need to consider a wide range of formal and informal learning experiences, both on and offline.  That information, more often than not is scattered across a wide variety of sources.
 
@@ -244,7 +244,7 @@ allows interactions between the two "trusted" parties.
 
 <a name="def-authorization" />
 
-__Authorization__: The affordance of permissions based on a user or system's role; 
+__Authorization__: The affordance of permissions based on a user's or system's role; 
 the process of making one user or system "trusted" by another.
 
 <a name="def-baseendpoint" />
@@ -393,7 +393,7 @@ different personas of the same user. The LRS can aggregate all of the informatio
 "Person" Object and send it through the Agents Resource.  
 
 
-### 5.1 Interoperbility Between Components
+### 5.1 Interoperability Between Components
 There are two main ways that the xAPI promotes interoperability between systems that implement the specification. The first is by 
 requiring that systems implementing the specification follow a consistent data structure. To that end, this specification defines 
 a data model for various data objects that are transferred between systems. The most significant object within the xAPI data model 
@@ -404,7 +404,7 @@ The second way that the xAPI promotes interoperability is by setting out the tra
 information about learning experiences between programs that adhere to the specification. As part of this, it sets out the format 
 of requests and the expected responses. Note that the systems storing or retrieving records need not be Activity Providers. LRSs 
 can communicate with other LRSs, or systems. xAPI follows the guidelines of the REST software architecture style, and as such data 
-is tranferred via HTTP requests and responses. xAPI also defines security methods allowing for the trusted exchange of information 
+is transferred via HTTP requests and responses. xAPI also defines security methods allowing for the trusted exchange of information 
 between the Learning Record Store and trusted sources.
 
 <a name="extending-xapi" />
@@ -507,7 +507,7 @@ Clarifications and additional examples including:
 - Complete reorganization of the document into three parts
 - Many, many clarifications
 - Removed back-references to SCORM
-- Addiitional explanitory text and diagrams
+- Additional explanatory text and diagrams
 [1.0.2...1.0.3](https://github.com/adlnet/xAPI-Spec/compare/1.0.2...1.0.3)
 
 <a name="parttwo" />


### PR DESCRIPTION
This is the results of a spell check across all three files. Whilst most of these are obvious fixes, some might be controversial such as:

* "un-ordered" to "unordered"
* "who" to "whom"

I'm happy to change either of those back if somebody feels strongly. 

For some reason the copy-paste process back and forwards to the spell checker has led to a small number of space characters getting replaced with a different space character, e.g. line 1017. I'm not sure why this is, but I don't think it matters. 

Fixes #612