### PR TITLE
Move suitable introduction to part 3 to become the part 3 introduction (and tweak wording)

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -3390,6 +3390,12 @@ attachment message format.
 
 # Part Three: Data Processing, Validation, and Security 
 
+This third part details the more technical side of the Experience API, dealing with 
+how Statements are transferred between Activity Provider and LRS. A number of libraries 
+are available for a range of technologies (including JavaScript) which handle 
+this part of the specification. It therefore might not be necessary for Activity Provider developers 
+to fully understand every detail of this part of the specification.
+
 <a name="requests"/>
 
 ## 1.0 Requests
@@ -3697,12 +3703,6 @@ described in [Section 6.4.2 OAuth Authorization Scope](#oauthscope).
 * Past, current and future versions of this specification do not and will not define endpoints 
 with path segments starting 'extensions/'. LRSs supporting additional endpoints not defined 
 in this specification SHOULD define those endpoints with path segments starting 'extensions/'.
-
-Sections 6 and 7 detail the more technical side of the Experience API, dealing with 
-how Statements are transferred between Activity Provider and LRS. A number of libraries 
-are under development for a range of technologies (including JavaScript) which handle 
-this part of the specification. It therefore might not be necessary for content developers 
-to fully understand every detail of this part of the specification.
 
 <a name="stmtres"/> 
 


### PR DESCRIPTION
* Moved paragraph from the middle to the start of part 3. 
* Changed reference from 'Sections 6 and 7' to part 3.
* Libraries are now available, not under development.
* Changed "content developers" to "Activity Provider developers".