### PR TITLE
Fix bullets in 2.2.1.2 POST Statements

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -3778,17 +3778,12 @@ that provide a lot of data to the LRS.
 with a statementID that it already has a Statement for. Whether it responds with
 ```409 Conflict``` or ```200 OK```, it MUST NOT modify the Statement or any other
 Object.
-
 * If the LRS receives a Statement with an id it already has a Statement for, it SHOULD
 verify the received Statement matches the existing one and return ```409 Conflict``` if they
 do not match. See [Statement comparision requirements]statement-comparision-requirements).
-
 * The LRS MAY respond before Statements that have been stored are available for retrieval.
-
 * GET Statements MAY be called using POST and form parameters if necessary as query strings 
-
 have limits. See Section [7.9 Alternate Request Syntax](#alt-request-syntax) for more details.
-
 * The LRS MUST differentiate a POST to add a Statement or to list Statements based on the 
 parameters passed. See Section [7.9 Alternate Request Syntax](#alt-request-syntax) for more details.
 

--- a/xAPI.md
+++ b/xAPI.md
@@ -3791,13 +3791,7 @@ verify the received Statement matches the existing one and return ```409 Conflic
 do not match. See [Statement comparision requirements]statement-comparision-requirements).
 * The LRS MAY respond before Statements that have been stored are available for retrieval.
 * GET Statements MAY be called using POST and form parameters if necessary as query strings 
-<<<<<<< HEAD
-have limits. See Section [7.9 Alternate Request Syntax](#alt-request-syntax) for more details.
-=======
-
 have limits. See [Alternate Request Syntax](#alt-request-syntax) for more details.
-
->>>>>>> adlnet/1.0.3-Restructure
 * The LRS MUST differentiate a POST to add a Statement or to list Statements based on the 
 parameters passed. See [Alternate Request Syntax](#alt-request-syntax) for more details.
 


### PR DESCRIPTION
Note: separately we need to go through all the bulleted lists in the document and standardize the line breaks. Most lists do not have line breaks between bullets. 