### PR TITLE
Format Markdown docs to pass linter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,99 +20,101 @@
 > leaders on which we depend to make our training and education the very best."
 >
 > _Kristy S. Murray, Ed.D._
+>
 > _Director, ADL Initiative_
+>
 > _OSD, Training Readiness & Strategy (TRS)_
 
 <a name="wg"/>
 
 ### Working Group Contributors
-  <table>
-    <tr><th>Name</th><th>Organization</th></tr>
-    <tr><td>Aaron Silvers</td><td>ADL</td></tr>
-    <tr><td>Al Bejcek</td><td>NetDimensions</td></tr>
-    <tr><td>Ali Shahrazad</td><td>SaLTBOX</td></tr>
-    <tr><td>Andrew Downes</td><td>Watershed</td></tr>
-    <tr><td>Andriy Drozdyuk</td><td></td></tr>
-    <tr><td>Andy Johnson</td><td>ADL</td></tr>
-    <tr><td>Andy Whitaker</td><td>Watershed</td></tr>
-    <tr><td>Ángel Serrano</td><td>eUCM</td></tr>
-    <tr><td>Anthony Altieri</td><td>American Red Cross</td></tr>
-    <tr><td>Anto Valan</td><td>Omnivera Learning Solutions</td></tr>
-    <tr><td>Avron Barr</td><td>Aldo Ventures, Inc.</td></tr>
-    <tr><td>Ben Clark</td><td>Rustici Software</td></tr>
-    <tr><td>Bill McDonald</td><td>Boeing</td></tr>
-    <tr><td>Brian J. Miller</td><td>Rustici Software</td></tr>
-    <tr><td>Chad Udell</td><td>Float Mobile Learning</td></tr>
-    <tr><td>Chaim-Leib Halbert</td><td>Rustici Software</td></tr>
-    <tr><td>Chris Handorf</td><td>Pearson</td></tr>
-    <tr><td>Chris Sawwa</td><td>Meridian Knowledge Solutions</td></tr>
-    <tr><td>Dan Allen</td><td>Litmos</td></tr>
-    <tr><td>Dan Kuemmel</td><td>Sentry Insurance</td></tr>
-    <tr><td>Danny Pham</td><td></td></tr>
-    <tr><td>Dave Mozealous</td><td>Articulate</td></tr>
-    <tr><td>David Ells</td><td>Rustici Software</td></tr>
-    <tr><td>David N. Johnson</td><td>Clear Learning Systems</td></tr>
-    <tr><td>David Pate</td><td>Riptide Software</td></tr>
-    <tr><td>Doug Hagy</td><td>Twin Lakes Consulting Corporation</td></tr>
-    <tr><td>Eric Johnson</td><td>Planning and Learning Technologies, Inc.</td></tr>
-    <tr><td>Fiona Leteney</td><td>Feenix e-learning</td></tr>
-    <tr><td>Greg Tatka</td><td>Menco Social Learning</td></tr>
-    <tr><td>Ingo Dahn</td><td>University Koblenz-Landau</td></tr>
-    <tr><td>Jason Haag</td><td>ADL</td></tr>
-    <tr><td>Jason Lewis</td><td>Yet Analytics</td></tr>
-    <tr><td>Jeff Place</td><td>Questionmark</td></tr>
-    <tr><td>Jennifer Cameron</td><td>Sencia Corporate Web Solutions</td></tr>
-    <tr><td>Jeremy Brockman</td><td> </td></tr>
-    <tr><td>Jhorlin De Armas</td><td>Riptide Software</td></tr>
-    <tr><td>Joe Gorup</td><td>CourseAvenue</td></tr>
-    <tr><td>Joerg Boeselt</td><td>Brightcookie</td></tr>
-    <tr><td>John Kleeman</td><td>Questionmark</td></tr>
-    <tr><td>Jonathan Archibald</td><td>Brightwave</td></tr>
-    <tr><td>Jonathan Poltrack</td><td>ADL</td></tr>
-    <tr><td>Kris Miller</td><td>edcetra Training</td></tr>
-    <tr><td>Kris Rockwell</td><td>Hybrid Learning Systems</td></tr>
-    <tr><td>Lang Holloman</td><td> </td></tr>
-    <tr><td>Lewis Cowper</td><td> </td></tr>
-    <tr><td>Loic Jeannin</td><td>CrossKnowledge</td></tr>
-    <tr><td>Lou Wolford</td><td>ADL</td></tr>
-    <tr><td>Luke Hickey</td><td>dominKnow</td></tr>
-    <tr><td>Marcus Birtwhistle</td><td>ADL</td></tr>
-    <tr><td>Mark Davis</td><td>Exambuilder</td></tr>
-    <tr><td>Matteo Scaramuccia</td><td> </td></tr>
-    <tr><td>Megan Bowe</td><td>Rustici Software</td></tr>
-    <tr><td>Melanie VanHorn</td><td>ADL</td></tr>
-    <tr><td>Michael Flores</td><td>Here Everything's Better</td></tr>
-    <tr><td>Michael Roberts</td><td>vTrainingRoom</td></tr>
-    <tr><td>Michael Wheeler</td><td></td></tr>
-    <tr><td>Mike Palmer</td><td>OnPoint Digital</td></tr>
-    <tr><td>Mike Rustici</td><td>Watershed</td></tr>
-    <tr><td>Nick Washburn</td><td>Riptide Software</td></tr>
-    <tr><td>Nikolaus Hruska</td><td>ADL</td></tr>
-    <tr><td>Pankaj Agrawal</td><td>Next Software Solutions</td></tr>
-    <tr><td>Patrick Kedziora</td><td>Kedzoh</td></tr>
-    <tr><td>Paul Esch</td><td>Nine Set</td></tr>
-    <tr><td>Paul Roberts</td><td>Questionmark</td></tr>
-    <tr><td>Rich Chetwynd</td><td>Litmos</td></tr>
-    <tr><td>Richard Fouchaux</td><td>Ontario Human Rights  Commission</td></tr>
-    <tr><td>Richard Lenz</td><td>Organizational Strategies, Inc.</td></tr>
-    <tr><td>Rick Raymer</td><td></td></tr>
-    <tr><td>RJ Zaworski</td><td></td></tr>
-    <tr><td>Rob Chadwick</td><td>ADL</td></tr>
-    <tr><td>Robert Lowe</td><td>NetDimensions</td></tr>
-    <tr><td>Roger Swetnam</td><td></td></tr>
-    <tr><td>Russell Duhon</td><td>SaLTBOX</td></tr>
-    <tr><td>Ryan Smith</td><td>HT2</td></tr>
-    <tr><td>Stephen Trevorrow</td><td>Problem Solutions, LLC.</td></tr>
-    <tr><td>Steve Baumgartner</td><td></td></tr>
-    <tr><td>Steve Flowers</td><td>XPConcept</td></tr>
-    <tr><td>Thomas Ho</td><td></td></tr>
-    <tr><td>Tim Martin</td><td>Rustici Software</td></tr>
-    <tr><td>Tom Creighton</td><td>ADL</td></tr>
-    <tr><td>Tyler Mulligan</td><td>ADL</td></tr>
-    <tr><td>Walt Grata</td><td>ADL</td></tr>
-    <tr><td>Yannick Warnier</td><td>Chamilo</td></tr>
-    <tr><td>Zach Lowry</td><td>Watershed</td></tr>
-</table>
+|Name                |   Organization             |
+|--------------------|----------------------------|
+| Aaron Silvers      | ADL                        |
+| Al Bejcek          | NetDimensions              |
+| Ali Shahrazad      | SaLTBOX                    |
+| Andrew Downes      | Watershed                  |
+| Andriy Drozdyuk    |                            |
+| Andy Johnson       | ADL                        |
+| Andy Whitaker      | Watershed                  |
+| Angel Serrano      | eUCM                       |
+| Anthony Altieri    | American Red Cross         |
+| Anto Valan         | Omnivera Learning Solutions |
+| Avron Barr         | Aldo Ventures, Inc. |
+| Ben Clark          | Rustici Software |
+| Bill McDonald      | Boeing |
+| Brian J. Miller    | Rustici Software |
+| Chad Udell         | Float Mobile Learning |
+| Chaim-Leib Halbert | Rustici Software |
+| Chris Handorf      | Pearson |
+| Chris Sawwa        | Meridian Knowledge Solutions |
+| Dan Allen          | Litmos |
+| Dan Kuemmel        | Sentry Insurance |
+| Danny Pham         |
+| Dave Mozealous     | Articulate |
+| David Ells         | Rustici Software |
+| David N. Johnson   | Clear Learning Systems |
+| David Pate         | Riptide Software |
+| Doug Hagy          | Twin Lakes Consulting Corporation |
+| Eric Johnson       | Planning and Learning Technologies, Inc. |
+| Fiona Leteney      | Feenix e-learning |
+| Greg Tatka         | Menco Social Learning |
+| Ingo Dahn          | University Koblenz-Landau |
+| Jason Haag         | ADL |
+| Jason Lewis        | Yet Analytics |
+| Jeff Place         | Questionmark |
+| Jennifer Cameron   | Sencia Corporate Web Solutions |
+| Jeremy Brockman    |
+| Jhorlin De Armas   | Riptide Software |
+| Joe Gorup          | CourseAvenue |
+| Joerg Boeselt      | Brightcookie |
+| John Kleeman       | Questionmark |
+| Jonathan Archibald | Brightwave |
+| Jonathan Poltrack  | ADL |
+| Kris Miller        | edcetra Training |
+| Kris Rockwell      | Hybrid Learning Systems |
+| Lang Holloman      |
+| Lewis Cowper       |
+| Loic Jeannin       | CrossKnowledge |
+| Lou Wolford        | ADL |
+| Luke Hickey        | dominKnow |
+| Marcus Birtwhistle | ADL |
+| Mark Davis         | Exambuilder |
+| Matteo Scaramuccia |
+| Megan Bowe         | Rustici Software |
+| Melanie VanHorn    | ADL |
+| Michael Flores     | Here Everything's Better |
+| Michael Roberts    | vTrainingRoom |
+| Michael Wheeler    |
+| Mike Palmer        | OnPoint Digital |
+| Mike Rustici       | Watershed |
+| Nick Washburn      | Riptide Software |
+| Nikolaus Hruska    | ADL |
+| Pankaj Agrawal     | Next Software Solutions |
+| Patrick Kedziora   | Kedzoh |
+| Paul Esch          | Nine Set |
+| Paul Roberts       | Questionmark |
+| Rich Chetwynd      | Litmos |
+| Richard Fouchaux   | Ontario Human Rights Commission |
+| Richard Lenz       | Organizational Strategies, Inc. |
+| Rick Raymer        |
+| RJ Zaworski        |
+| Rob Chadwick       | ADL |
+| Robert Lowe        | NetDimensions |
+| Roger Swetnam      |
+| Russell Duhon      | SaLTBOX |
+| Ryan Smith         | HT2 |
+| Stephen Trevorrow  | Problem Solutions, LLC. |
+| Steve Baumgartner  |
+| Steve Flowers      | XPConcept |
+| Thomas Ho          |
+| Tim Martin         | Rustici Software |
+| Tom Creighton      | ADL |
+| Tyler Mulligan     | ADL |
+| Walt Grata         | ADL |
+| Yannick Warnier    | Chamilo |
+| Zach Lowry         | Watershed |
+
 
 ><a name="reqparticipants"/>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,30 +1,31 @@
-xAPI-Spec
-=========
+# xAPI-Spec
 
-<a name="contributors"/> 
 
-##Contributors
+<a name="contributors"/>
+
+## Contributors
 
 ### Message To Contributors
-_"My thanks to everyone who contributed to the Experience API project. Many of 
-you have called into the weekly meetings and helped to shape the specification 
-into something that is useful for the entire distributed learning community. 
-Many of you assisted in releasing code samples, products, and documentation to 
-aid those who are creating and adopting the specification.  I'd also like to 
-thank all of those who were involved in supplying useful, honest information 
-about your organization's use of SCORM and other learning best practices. 
-Through the use-cases, shared experiences, and knowledge you have shared, ADL 
-and the community clearly identified the first step in creating the Training 
-and Learning Architecture--the Experience API.  You are truly the community 
-leaders on which we depend to make our training and education the very best."_ 
 
->Kristy S. Murray, Ed.D.  
->Director, ADL Initiative  
->OSD, Training Readiness & Strategy (TRS)  
+> "My thanks to everyone who contributed to the Experience API project. Many of
+> you have called into the weekly meetings and helped to shape the specification
+> into something that is useful for the entire distributed learning community.
+> Many of you assisted in releasing code samples, products, and documentation to
+> aid those who are creating and adopting the specification.  I'd also like to
+> thank all of those who were involved in supplying useful, honest information
+> about your organization's use of SCORM and other learning best practices.
+> Through the use-cases, shared experiences, and knowledge you have shared, ADL
+> and the community clearly identified the first step in creating the Training
+> and Learning Architecture--the Experience API.  You are truly the community
+> leaders on which we depend to make our training and education the very best."
+>
+> _Kristy S. Murray, Ed.D._
+> _Director, ADL Initiative_
+> _OSD, Training Readiness & Strategy (TRS)_
 
 <a name="wg"/>
 
-### Working Group Contributors  
+### Working Group Contributors
   <table>
     <tr><th>Name</th><th>Organization</th></tr>
     <tr><td>Aaron Silvers</td><td>ADL</td></tr>
@@ -111,29 +112,29 @@ leaders on which we depend to make our training and education the very best."_
     <tr><td>Walt Grata</td><td>ADL</td></tr>
     <tr><td>Yannick Warnier</td><td>Chamilo</td></tr>
     <tr><td>Zach Lowry</td><td>Watershed</td></tr>
-</table> 
+</table>
 
-><a name="reqparticipants"/> 
+><a name="reqparticipants"/>
 
 
-### Historical Contributors  
-In collection of requirements for the Experience API, many people and 
+### Historical Contributors
+In collection of requirements for the Experience API, many people and
 organizations provided invaluable feedback to the SCORM, distributed learning efforts, and learning technology
-efforts in general.  While not an exhaustive listing, the white papers gathered 
-in 2008 by the Learning Education and Training Standards Interoperability (LETSI) 
+efforts in general.  While not an exhaustive listing, the white papers gathered
+in 2008 by the Learning Education and Training Standards Interoperability (LETSI)
 group, the Rustici Software UserVoice website, one-on-one interviews and various
-blogs were important sources from which requirements were gathered for the 
+blogs were important sources from which requirements were gathered for the
 Experience API specification.
 
 <a name="adlrole"/>
 
-#### ADL's Role in the Experience API  
-The Advanced Distributed Learning (ADL) Initiative has taken on the roles of steward and facilitator 
-in the development of the Experience API.  The Experience API is seen as one piece of the ADL Training 
-and Learning Architecture, which facilitates learning anytime and anywhere. ADL views the Experience API 
-as an evolved version of Sharable Content Object Reference Model (SCORM) that can support similar use cases, 
-but can also support many of the use cases gathered by ADL and submitted by those involved in distributed 
-learning that SCORM could not enable.  
+#### ADL's Role in the Experience API
+The Advanced Distributed Learning (ADL) Initiative has taken on the roles of steward and facilitator
+in the development of the Experience API.  The Experience API is seen as one piece of the ADL Training
+and Learning Architecture, which facilitates learning anytime and anywhere. ADL views the Experience API
+as an evolved version of Sharable Content Object Reference Model (SCORM) that can support similar use cases,
+but can also support many of the use cases gathered by ADL and submitted by those involved in distributed
+learning that SCORM could not enable.
 
 ##How to Contribute
 
@@ -145,182 +146,182 @@ This document outlines various ways of contributing to the specification:
 
 <a name='review-pr'/>
 ### Review a Pull Request (PR)
-The most helpful **and** easiest way to contribute to the specification is to review an existing PR. You can find a 
+The most helpful **and** easiest way to contribute to the specification is to review an existing PR. You can find a
 [list of open PRs here](https://github.com/adlnet/xAPI-Spec/pulls). To review a PR you should:
 
-* Read any issues linked to from the PR description and make sure you understand the issue the PR is designed to address. 
+* Read any issues linked to from the PR description and make sure you understand the issue the PR is designed to address.
 * Read any comments on both the issues and the PR to understand if the goals of the original issue have changed and if
-any solutions have been agreed. 
-* Read the relevant sections in the [development version](https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI.md) of the specification. 
+any solutions have been agreed.
+* Read the relevant sections in the [development version](https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI.md) of the specification.
 * Check the 'Files changed' tab of the PR and look at what has changed. Use the 'rich diff' option if that helps you to see
-the changes better. Check to see if what's been changed matches the solution you expected from reading the issue and comments. 
-* Look for problems such as typos, unintended changes to behaviour and any text that's unclear. 
-* Check that anything that's been removed has either been replaced or the removal was intentional (based on reading the issue 
+the changes better. Check to see if what's been changed matches the solution you expected from reading the issue and comments.
+* Look for problems such as typos, unintended changes to behaviour and any text that's unclear.
+* Check that anything that's been removed has either been replaced or the removal was intentional (based on reading the issue
 and comments).
 * Check that the [Style Guide](#style-guide) has been followed.
 * If you spot any issues with the PR, add a comment describing these problems as best you can and suggesting how they can
-be resolved. 
+be resolved.
 * If the PR looks good to you, add a comment saying "+1".
-* If you are unsure about the PR or have questions, ask questions in the PR comments. 
+* If you are unsure about the PR or have questions, ask questions in the PR comments.
 * If you feel that the PR should never be merged, even with changes, add a comment starting with "-1" and explaining your
 reasons. If your comments run contrary to what's already been agreed in the issues, there might be some resistance, but that's ok
-if you have a strong argument! 
+if you have a strong argument!
 
 When reviewing a PR please don't:
 
 * Review and leave no comment; always let us know you've had a look!
-* Suggest additional changes outside of what the PR was intended to achieve. 
-[Raise a separate issue](https://github.com/adlnet/xAPI-Spec/issues/new) for additional changes. 
-* Make vague criticisms without suggesting the changes to the PR that would meet those criticisms. 
+* Suggest additional changes outside of what the PR was intended to achieve.
+[Raise a separate issue](https://github.com/adlnet/xAPI-Spec/issues/new) for additional changes.
+* Make vague criticisms without suggesting the changes to the PR that would meet those criticisms.
 
 <a name='suggest-solution'/>
 ### Suggest a solution
-The second most helpful and second easiest way to contribute to the specification is to suggest a solution to an issue that has been raised. 
-Ideally the person who raises the issue will propose a solution, but this does not always happen and you may be able to improve a suggestion. 
+The second most helpful and second easiest way to contribute to the specification is to suggest a solution to an issue that has been raised.
+Ideally the person who raises the issue will propose a solution, but this does not always happen and you may be able to improve a suggestion.
 
 To suggest a solution to an issue you should:
 
-* Read the issue and ensure you understand the problem being described. Ask questions if you need to. 
-* Read the relevant sections in the [development version](https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI.md) of the specification. 
+* Read the issue and ensure you understand the problem being described. Ask questions if you need to.
+* Read the relevant sections in the [development version](https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI.md) of the specification.
 * Add a comment stating:
     * Which sections of the specification you propose to change.
-    * A description of the proposed change. 
-    * Any reasons for and against the change you're proposing. 
+    * A description of the proposed change.
+    * Any reasons for and against the change you're proposing.
 
 Once your suggestion has been discussed and agreed, add another comment summarising your understanding of the outcome of the discussion and
-including proposed wording for the changes you've suggested. 
+including proposed wording for the changes you've suggested.
 
-Good and detailed suggested solutions for issues make it much easier to write PRa and helps to ensure those PRs are merged faster. 
+Good and detailed suggested solutions for issues make it much easier to write PRa and helps to ensure those PRs are merged faster.
 
 <a name='make-pr'/>
 ### Make a Pull Request (PR)
 The hardest way of directly contributing to the specification is to make Pull Requests and the xAPI Working Group recommends only getting involved in
-this way if you are already used to Github and markdown and/or have previously contributed to reviewing PRs and suggesting solutions to issues. 
+this way if you are already used to Github and markdown and/or have previously contributed to reviewing PRs and suggesting solutions to issues.
 
 Before making a PR you should:
 * Read the issue you are planning to address carefully including any comments.
 * Read the relevant sections in the [development version](https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI.md) of the specification.
-* Read any suggested solutions to the issue and the discussion around those issues. 
+* Read any suggested solutions to the issue and the discussion around those issues.
 
-If you would like to raise a PR that directly addresses your own concern, there is no need to raise a separate issue. 
+If you would like to raise a PR that directly addresses your own concern, there is no need to raise a separate issue.
 
-To make a PR you will need to edit xAPI.md either using the GitHub.com interface, or use git on your local computer. 
+To make a PR you will need to edit xAPI.md either using the GitHub.com interface, or use git on your local computer.
 The GitHub.com interface is simpler for new users and is ideal for smaller changes like typos. These two methods are described below.
 
 When making a PR, you should include a description that explains:
 * What issue numbers of any issues you are addressing (normally just one issue)?
 * How does your PR relate to any proposed solutions to the issue?
 * If you have moved sections, have you made any changes to content within those moved sections?
-* What decisions did you make in writing the change? Why did you make those decisions? 
+* What decisions did you make in writing the change? Why did you make those decisions?
 
 #### Edit on GitHub.com
-To edit the specification on GitHub.com, first open the [development version](https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI.md) 
-of the specification, then [follow the instructions here](https://help.github.com/articles/editing-files-in-another-user-s-repository/). 
+To edit the specification on GitHub.com, first open the [development version](https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI.md)
+of the specification, then [follow the instructions here](https://help.github.com/articles/editing-files-in-another-user-s-repository/).
 
 #### Edit Locally
 
 ##### Set up
-If you are not currently working with GitHub and git, follow these set up steps 
+If you are not currently working with GitHub and git, follow these set up steps
 first. GitHub provides excellent help at [https://help.github.com/articles/set-up-git](https://help.github.com/articles/set-up-git)
 
 ##### Fork the ADL repository
-Go to the Experience API repository. Fork the repository to your own account using 
-the "Fork" button on the top right of Experience API repository page. This makes a 
-copy of the Experience API repository. This fork gives you the ability to edit your 
+Go to the Experience API repository. Fork the repository to your own account using
+the "Fork" button on the top right of Experience API repository page. This makes a
+copy of the Experience API repository. This fork gives you the ability to edit your
 version of the document without impacting the master copy.
 
 ##### Install Git (use cmd line) or Install Windows/Mac GitHub client
-You need to install Git to work with a GitHub repository. If you are on a Windows machine, 
-you can download the GitHub client app. If you use a Mac you can download the GitHub client app 
-but will also have to download git to add a remote to the master repository. Otherwise install git from the 
+You need to install Git to work with a GitHub repository. If you are on a Windows machine,
+you can download the GitHub client app. If you use a Mac you can download the GitHub client app
+but will also have to download git to add a remote to the master repository. Otherwise install git from the
 git site.
 
-__Git__  
-This provides a command line client app for working with a git repository (like 
-GitHub)  
+__Git__
+This provides a command line client app for working with a git repository (like
+GitHub)
 Download and run [git install](http://git-scm.com/downloads)
 
-__GitHub Client__  
-GitHub Client provides a GUI interface to simplify working with a repository on 
-GitHub. This does not currently support synchronizing with a master repository so 
+__GitHub Client__
+GitHub Client provides a GUI interface to simplify working with a repository on
+GitHub. This does not currently support synchronizing with a master repository so
 some commands will still need to be completed using the command line.
 
-__Mac:__ http://mac.github.com/  
+__Mac:__ http://mac.github.com/
 __Windows:__ http://windows.github.com/
 
 
 ##### Clone your GitHub fork to your machine
-To make edits and work on the files in the repository, clone your repository to 
-your local machine using Git. The url is provided on the home page of your 
-repository (ex. ```https://github.com/<your username>/xAPI-Spec/```)  
+To make edits and work on the files in the repository, clone your repository to
+your local machine using Git. The url is provided on the home page of your
+repository (ex. ```https://github.com/<your username>/xAPI-Spec/```)
 
-__Git__  
-```git clone https://github.com/<your username>/xAPI-Spec/>```  
+__Git__
+```git clone https://github.com/<your username>/xAPI-Spec/>```
 
-__GitHub Client__  
-On the home screen of the client app, select your account under 'github' and 
-choose the repository you want to clone. Selecting the repository from the list 
-gives you an option to clone it. 
+__GitHub Client__
+On the home screen of the client app, select your account under 'github' and
+choose the repository you want to clone. Selecting the repository from the list
+gives you an option to clone it.
 
 ##### Add ADL repository as upstream remote
-Add a remote repository to git to reference the master repository. This will make 
-synchronizing with the master repository a bit easier.  
+Add a remote repository to git to reference the master repository. This will make
+synchronizing with the master repository a bit easier.
 
-__Git__  
-```git remote add upstream https://github.com/adlnet/xAPI-Spec```  
+__Git__
+```git remote add upstream https://github.com/adlnet/xAPI-Spec```
 
-__GitHub Client__  
-Currently the GitHub clients don't have a way to synchronize with the master 
-repository. In order to do this, open your repository on the GitHub client 
-app home screen. On the repository screen select 'tools' and 'open a shell 
-here'. Alternatively use the 'Git Shell' shortcut if it was created during 
-installation. **NOTE:** If you're using a Mac there is no shell shortcut so 
+__GitHub Client__
+Currently the GitHub clients don't have a way to synchronize with the master
+repository. In order to do this, open your repository on the GitHub client
+app home screen. On the repository screen select 'tools' and 'open a shell
+here'. Alternatively use the 'Git Shell' shortcut if it was created during
+installation. **NOTE:** If you're using a Mac there is no shell shortcut so
 navigate to ```/your/repo/path/xAPI-Spec``` then follow the shell instructions.
-  
-In the shell, enter..  
-```git remote add upstream https://github.com/adlnet/xAPI-Spec```  
+
+In the shell, enter..
+```git remote add upstream https://github.com/adlnet/xAPI-Spec```
 
 
 #### Workflow
 
 ##### Sync up with ADL Repository development
-Pull down changes from the development repository. This automatically does a 
+Pull down changes from the development repository. This automatically does a
 fetch of the repository and a merge into your local repository. Currently
 the development version of the spec is 1.0.3.
 
-__Git and GitHub Client__  
+__Git and GitHub Client__
 ```git pull upstream 1.0.3```
 
 ##### Make Changes Locally
-Edit the local copy of the file, save and commit. Rule of thumb: Use commits 
-like save points. Commit to indicate logical groups of edits, and places 
-where the edits could be safely rolled back.  
+Edit the local copy of the file, save and commit. Rule of thumb: Use commits
+like save points. Commit to indicate logical groups of edits, and places
+where the edits could be safely rolled back.
 
-__Git__  
-```git commit -a -m "<commit message>"```  
+__Git__
+```git commit -a -m "<commit message>"```
 
-__GitHub Client__  
-The GitHub client will detect saved changes to the documents in your 
-local repository and present a button to commit your edits at the top 
-right of the repository screen.  
+__GitHub Client__
+The GitHub client will detect saved changes to the documents in your
+local repository and present a button to commit your edits at the top
+right of the repository screen.
 
 ##### Push Changes to Your Repository (Origin)
-Pushing your changes to your remote GitHub repository stages the files 
-so that you can then make requests to the master repository to merge in 
+Pushing your changes to your remote GitHub repository stages the files
+so that you can then make requests to the master repository to merge in
 your changes.
 
-__Git__  
+__Git__
 ```git push origin```
 
-__GitHub Client__  
-The GitHub client has a 'sync' button at the top of the repository screen. 
-This will synchronize your local and remote (origin) repository.  
+__GitHub Client__
+The GitHub client has a 'sync' button at the top of the repository screen.
+This will synchronize your local and remote (origin) repository.
 
 ##### Submit a Pull Request to Master ADL Repository (Upstream)
-When you forked from the Experience API repository, a link back to the master 
-repository is remembered. To send your changes back the the master repository, 
-click the "Pull Request" button at the top of your repository page. This will 
-direct you to a page that gives you the ability to submit a request to the 
+When you forked from the Experience API repository, a link back to the master
+repository is remembered. To send your changes back the the master repository,
+click the "Pull Request" button at the top of your repository page. This will
+direct you to a page that gives you the ability to submit a request to the
 master repository to merge in the changes you committed.
 
 <a name='style-guide'/>
@@ -339,18 +340,18 @@ And
 
 ### Property and object names
 
-When referring to a property, parameter or object, but not specifically calling it out as property, parameter, or object 
-the name should be capitalized. No formatting or quotes should be used. 
+When referring to a property, parameter or object, but not specifically calling it out as property, parameter, or object
+the name should be capitalized. No formatting or quotes should be used.
 
 For example:
 
     Context Activities within the Context of the Statement are awesome.
 
-When a specific type is called out, Double quotes should be used (e.g. properties, parameters, and objects). When used within quotes, the capitalization should match that actually used in the object being described. 
+When a specific type is called out, Double quotes should be used (e.g. properties, parameters, and objects). When used within quotes, the capitalization should match that actually used in the object being described.
 
 For example:
 
-    You can use "category" Context Activities to denote the recipe being followed in crafting the statement. 
+    You can use "category" Context Activities to denote the recipe being followed in crafting the statement.
 
 And
 
@@ -372,7 +373,7 @@ And
 And
 
     The Score Object SHOULD include 'scaled'
-  
+
 And
 
     The 'binary' value should be used.

--- a/README.md
+++ b/README.md
@@ -1,39 +1,54 @@
-xAPI-Spec
-=========
+# xAPI-Spec
 
-This Github repository contains the xAPI Specification. xAPI is a learning technologies interoperability specification that describes communication 
-about learner activity and experiences between technologies. You can [read the latest release of the specification here](xAPI.md).  The group meets the first, second, and third Wednesdays of each month on GoToWebinar.  You can register [at https://attendee.gotowebinar.com/register/279276321478091778](https://attendee.gotowebinar.com/register/279276321478091778)
+This Github repository contains the xAPI Specification. xAPI is a learning
+technologies interoperability specification that describes communication
+about learner activity and experiences between technologies. You can
+[read the latest release of the specification here](xAPI.md).  The group meets
+the first, second, and third Wednesdays of each month on GoToWebinar.  You can
+register [at https://attendee.gotowebinar.com/register/279276321478091778](https://attendee.gotowebinar.com/register/279276321478091778)
 
 ## Specification versions
-The current version of the specification is [1.0.2](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI.md). 
-[1.0.3](https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI.md) is currently being developed by
-the specification working group. 
 
-##What to do if the spec is unclear
-If when implementing the specification you find something is unclear or unhelpful, it may be that the others have similarly found that
-section unclear and that it has been fixed in the 
-[development version of the specification (1.0.3)](https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI.md) which is being developed by the 
-xAPI Working Group. You can and should look at the development version of the specification for reference, but be aware that this version has
-not been published; it could contain errors and might be changed before it is released. 
+The current version of the specification is
+[1.0.2](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI.md).
+[1.0.3](https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI.md) is currently
+being developed by the specification working group.
 
-If your confusions and concerns have not been addressed in the [development version)](https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI.md), 
-you can help to improve the specification by [raising an issue here](https://github.com/adlnet/xAPI-Spec/issues). When raising an issue, 
-please give as much detail as you can in regards to:
+## What to do if the spec is unclear
+
+If when implementing the specification you find something is unclear or
+unhelpful, it may be that the others have similarly found that
+section unclear and that it has been fixed in the
+[development version of the specification (1.0.3)](https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI.md)
+which is being developed by the xAPI Working Group. You can and should look at
+the development version of the specification for reference, but be aware that
+this version has not been published; it could contain errors and might be
+changed before it is released.
+
+If your confusions and concerns have not been addressed in the [development version)](https://github.com/adlnet/xAPI-Spec/blob/1.0.3/xAPI.md),
+you can help to improve the specification by
+[raising an issue here](https://github.com/adlnet/xAPI-Spec/issues). When
+raising an issue, please give as much detail as you can in regards to:
 
 * Which part/parts of the specification you are reading.
 * Your understanding of what these parts mean.
-* The product and feature you are implementing xAPI in; what's the use case you are trying to achieve?
-* How you would like the specification to be improved. Suggest some specific new wording if you like!
+* The product and feature you are implementing xAPI in; what's the use case you
+  are trying to achieve?
+* How you would like the specification to be improved. Suggest some specific new
+  wording if you like!
 
-You'll need to [sign up for a GitHub account](https://github.com/signup/free) if you do not already have one in order
-to raise and comment on issues. 
+You'll need to [sign up for a GitHub account](https://github.com/signup/free) if
+you do not already have one in order to raise and comment on issues.
 
-You can discuss any issues before or after raising them on the [specification Google Group](https://groups.google.com/a/adlnet.gov/forum/#!forum/xapi-spec)
-and at our [weekly specification calls](https://attendee.gotowebinar.com/register/100000000063672381). 
+You can discuss any issues before or after raising them on the
+[specification Google Group](https://groups.google.com/a/adlnet.gov/forum/#!forum/xapi-spec)
+and at our
+[weekly specification calls](https://attendee.gotowebinar.com/register/100000000063672381).
 
-##How you can contribute
-You'll need to [sign up for a GitHub account](https://github.com/signup/free) if you do not already have one in order
-to contribute to the specification. 
+## How you can contribute
+
+You'll need to [sign up for a GitHub account](https://github.com/signup/free) if
+you do not already have one in order to contribute to the specification.
 
 In addition to raising and discussing issues, you can contribute by:
 
@@ -41,4 +56,4 @@ In addition to raising and discussing issues, you can contribute by:
 * [Suggesting solutions to issues](CONTRIBUTING.md#suggest-solution)
 * [Making a Pull Request to address an issue](CONTRIBUTING.md#make-pr)
 
-Click the links above to find out how to do each of these things. 
+Click the links above to find out how to do each of these things.


### PR DESCRIPTION
This is an intial commit tackiling low-hanging fruit to get the spec docs passing markdown linting, so that any contributor with any editor can reliably edit the various pieces.

I tackled README.md first since it had few issues, just formatting things like whitespace and blank lines around headers and lists. It now passes the linter without complaint. 

Please see #829 for details; the goal is to set up CI testing so that PRs pass the linter prior to inclusion, this is a first pass on low-hanging fruit.