### PR TITLE
Use JWS Compact Serialization please.

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -2369,6 +2369,9 @@ for discoverability of the signer X.509 certificates SHOULD be used.
 * A Signed Statement MUST include a JSON web signature (JWS) as defined here:
 http://tools.ietf.org/html/draft-ietf-jose-json-web-signature, as an attachment with a usageType
 of "http://adlnet.gov/expapi/attachments/signature" and a contentType of "application/octet-stream".
+* JWS Compact Serialization SHOULD* be used to create the JSON web signature. Use of JWS JSON Serialization is 
+strongly discouraged, is unlikely to be interoperble with other systems, and will be forbidden in a future version
+of this specification. 
 * The JWS signature MUST have a payload of a valid JSON serialization of the complete Statement, minus signature.
 * The JWS signature MUST use an algorithm of "RS256","RS384", or "RS512".
 * The JWS signature SHOULD have been created based on the private key associated with an


### PR DESCRIPTION
Fixes #736 

If you are using JWS JSON Serialization instead of JWS Compact Serialization to sign statement or verify signed statements, now is the time to speak up. 