### PR TITLE
strengthened duplicate requirement in batches

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -3751,7 +3751,7 @@ verify the received Statement matches the existing one and SHOULD return ```409 
 do not match. See [Statement comparision requirements](statement-comparision-requirements).
 
 * If the LRS receives a Statement with an id it already has a Statement for **in the same batch**, it SHOULD*
-verify the received Statement matches the existing one and SHOULD return ```409 Conflict``` if they
+verify the received Statement matches the existing one and SHOULD return ```400 Bad Request``` if they
 do not match. See [Statement comparision requirements](statement-comparision-requirements).
 
 * The LRS MAY respond before Statements that have been stored are available for retrieval.

--- a/xAPI.md
+++ b/xAPI.md
@@ -3750,6 +3750,10 @@ Object.
 verify the received Statement matches the existing one and SHOULD return ```409 Conflict``` if they
 do not match. See [Statement comparision requirements](statement-comparision-requirements).
 
+* If the LRS receives a Statement with an id it already has a Statement for **in the same batch**, it SHOULD*
+verify the received Statement matches the existing one and SHOULD return ```409 Conflict``` if they
+do not match. See [Statement comparision requirements](statement-comparision-requirements).
+
 * The LRS MAY respond before Statements that have been stored are available for retrieval.
 
 ###### Activity Provider Requirements


### PR DESCRIPTION
The reason the original requirement is a `SHOULD` instead of a `MUST` is to avoid unreasonably burdening distributed systems, which are not going to be able to reasonably perform such a check. However, this requirement doesn't add an unreasonable burden for such systems when applied only within the scope of a single batch, so there is no reason it shouldn't be a `MUST` there, so I'm suggesting we make it a `SHOULD*` in that particular case.

This came up as a result of the discussion here: https://github.com/adlnet/xAPI_LRS_Test/issues/54