### PR TITLE
Remove extra `<`

### DIFF
--- a/xAPI.md
+++ b/xAPI.md
@@ -3113,7 +3113,7 @@ Returns: ```204 No Content```
 	</tr>
 	<tr>
 		<td>agent</td>
-		<td>JSON<</td>
+		<td>JSON</td>
 		<td>The Agent associated with this state.</td>
 		<td>Required</td>
 	</tr>


### PR DESCRIPTION
Just a simple update to remove an extra `<` within the Document APIs. I checked the rest of the document as well to make sure there weren't additional such errors.