### PR TITLE
Update signed statements section to reference current JWS spec

### DIFF
--- a/xAPI-Data.md
+++ b/xAPI-Data.md
@@ -1812,7 +1812,7 @@ for discoverability of the signer X.509 certificates SHOULD be used.
 ##### Signature Requirements
 * A Signed Statement MUST include a JSON web signature (JWS) as defined here:
 http://tools.ietf.org/html/draft-ietf-jose-json-web-signature, as an attachment with a usageType
-of "http://adlnet.gov/expapi/attachments/signature" and a contentType of "application/octet-stream".
+of "http://adlnet.gov/expapi/attachments/signature" and a contentType of "application/jose".
 * JWS Compact Serialization SHOULD* be used to create the JSON web signature. Use of JWS JSON Serialization is 
 strongly discouraged, is unlikely to be interoperble with other systems, and will be forbidden in a future version
 of this specification. 

--- a/xAPI-Data.md
+++ b/xAPI-Data.md
@@ -1810,8 +1810,8 @@ For interoperability, the "RSA + SHA" series of JWS algorithms have been selecte
 for discoverability of the signer X.509 certificates SHOULD be used.
 
 ##### Signature Requirements
-* A Signed Statement MUST include a JSON web signature (JWS) as defined here:
-http://tools.ietf.org/html/draft-ietf-jose-json-web-signature, as an attachment with a usageType
+* A Signed Statement MUST include a JSON web signature (JWS) as defined in [RFC7515](
+https://tools.ietf.org/html/rfc7515) as an attachment with a usageType
 of "http://adlnet.gov/expapi/attachments/signature" and a contentType of "application/jose".
 * JWS Compact Serialization SHOULD* be used to create the JSON web signature. Use of JWS JSON Serialization is 
 strongly discouraged, is unlikely to be interoperble with other systems, and will be forbidden in a future version


### PR DESCRIPTION
As of May 2015, JSON Web Signatures have left "draft" status and been officially endorsed as [RFC 7515](https://tools.ietf.org/html/rfc7515). This PR updates the link to point to the new RFC.

It also changes the contentType of statement signatures from `application/octet-stream` to `application/jose`, as required by the RFC (and the older draft, incidentally).

Thoughts?