### PR TITLE
Add "or known to be 0.9 due to the  lack of a version header"

### DIFF
--- a/xAPI-Communication.md
+++ b/xAPI-Communication.md
@@ -1638,7 +1638,8 @@ of previously intended behavior.
 * <a name="3.3.s3.b2"></a>The LRS MUST set this header to the latest patch version.
 * <a name="3.3.s3.b3"></a>The LRS MUST accept requests with a version header of `1.0` as if the version header was `1.0.0`.
 * <a name="3.3.s3.b4"></a>The LRS MUST reject requests with version header prior to version 1.0.0 unless such requests are 
-routed to a fully conformant implementation of the prior version specified in the header.
+routed to a fully conformant implementation of the prior version specified in the header, or known to be 0.9 due to the 
+lack of a version header.
 * <a name="3.3.s3.b5"></a>The LRS MUST accept requests with a version header starting with `1.0.` if the request is otherwise valid. 
 * <a name="3.3.s3.b6"></a>The LRS MUST reject requests with a version header of `1.1.0` or greater.
 * <a name="3.3.s3.b7"></a>The LRS MUST make these rejects by responding with a `400 Bad Request` error including a short 

--- a/xAPI-Communication.md
+++ b/xAPI-Communication.md
@@ -1638,8 +1638,9 @@ of previously intended behavior.
 * <a name="3.3.s3.b2"></a>The LRS MUST set this header to the latest patch version.
 * <a name="3.3.s3.b3"></a>The LRS MUST accept requests with a version header of `1.0` as if the version header was `1.0.0`.
 * <a name="3.3.s3.b4"></a>The LRS MUST reject requests with version header prior to version 1.0.0 unless such requests are 
-routed to a fully conformant implementation of a prior version. This prior version MUST be the version specified in the 
-version header, or 0.9 in the case of a lack of version header.
+routed to a fully conformant implementation of the prior version specified in the header.
+* <a name="3.3.s3.b4.1"></a>The LRS MUST reject requests without a version header unless such requests are 
+routed to a fully conformant 0.9 implementation.
 * <a name="3.3.s3.b5"></a>The LRS MUST accept requests with a version header starting with `1.0.` if the request is otherwise valid. 
 * <a name="3.3.s3.b6"></a>The LRS MUST reject requests with a version header of `1.1.0` or greater.
 * <a name="3.3.s3.b7"></a>The LRS MUST make these rejects by responding with a `400 Bad Request` error including a short 

--- a/xAPI-Communication.md
+++ b/xAPI-Communication.md
@@ -1638,8 +1638,8 @@ of previously intended behavior.
 * <a name="3.3.s3.b2"></a>The LRS MUST set this header to the latest patch version.
 * <a name="3.3.s3.b3"></a>The LRS MUST accept requests with a version header of `1.0` as if the version header was `1.0.0`.
 * <a name="3.3.s3.b4"></a>The LRS MUST reject requests with version header prior to version 1.0.0 unless such requests are 
-routed to a fully conformant implementation of the prior version specified in the header, or known to be 0.9 due to the 
-lack of a version header.
+routed to a fully conformant implementation of a prior version. This prior version MUST be the version specified in the 
+version header, or 0.9 in the case of a lack of version header.
 * <a name="3.3.s3.b5"></a>The LRS MUST accept requests with a version header starting with `1.0.` if the request is otherwise valid. 
 * <a name="3.3.s3.b6"></a>The LRS MUST reject requests with a version header of `1.1.0` or greater.
 * <a name="3.3.s3.b7"></a>The LRS MUST make these rejects by responding with a `400 Bad Request` error including a short 


### PR DESCRIPTION
Fixes #980.

I ended up splitting this into two separate requirements. See commit history for the chain of thought. 

I think we're perfectly fine with this new requirement being a MUST because it's required to validate and reject requests based on the value of that header and the client MUST include it. 
