### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ anywhere. ADL views the Experience API as an evolved version of Sharable Content
 that can support similar use cases, but can also support many of the use cases gathered by ADL and submitted by
 those involved in distributed learning that SCORM could not enable.
 
-##How to Contribute
+## How to Contribute
 
 This document outlines various ways of contributing to the specification:
 
@@ -323,7 +323,7 @@ direct you to a page that gives you the ability to submit a request to the
 master repository to merge in the changes you committed.
 
 <a name='style-guide'/>
-##Style Guide
+## Style Guide
 ### Expected Values
 
 If a specific data format and value are to be used, the `code` style should be used to denote this.

--- a/xAPI-About.md
+++ b/xAPI-About.md
@@ -102,7 +102,7 @@
 		*	[Appendix C: Cross Domain Request Example](./xAPI-Communication.md#Appendix3C)  
 
 <a name="partone" />
-#Part One: About the Experience API
+# Part One: About the Experience API
 
 <a name="introduction-partone"></a>
 ## 1.0 Introduction

--- a/xAPI-Data.md
+++ b/xAPI-Data.md
@@ -103,7 +103,7 @@
 
 
 <a name="parttwo" />
-#Part Two: Experience API Data
+# Part Two: Experience API Data
 
 <a name="documents" />
 ## <a name="1.0">1.0</a> Documents


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
