### PR TITLE
Correct rendering in 2.5.s2 table

### DIFF
--- a/xAPI-Data.md
+++ b/xAPI-Data.md
@@ -1799,7 +1799,6 @@ The following table shows the data structure for the results of queries on the S
 			and there are more results, they will be located at the "statements" property 
 			within the container located at the IRL provided by the "more" property of 
 			this Statement result Object.
-			
 			Where no matching Statements are found, this property will contain an empty array.
 		</td>
 		<td>Required</td>


### PR DESCRIPTION
This removes an extra blank line that caused a bug in the rendering of the table on GitHub.