### PR TITLE
Removed extra qs parameter alt syntax example

### DIFF
--- a/xAPI-Communication.md
+++ b/xAPI-Communication.md
@@ -2197,7 +2197,7 @@ Content:
 Request using alternative syntax:
 
 ```
-URL: http://example.com/xAPI/statements?method=PUT&statementId=c70c2b85-c294-464f-baca-cebd4fb9b348
+URL: http://example.com/xAPI/statements?method=PUT
 Method: POST
 
 Request Headers:


### PR DESCRIPTION
Removed the extra "statementId" parameter from the alternate syntax request example.

> The intended xAPI method MUST be included as the value of the "method" query string parameter.
> The Learning Record Provider MUST NOT include any other query string parameters on the request.

duplicate of https://github.com/adlnet/xAPI-Spec/pull/1059 , as requested