### PR TITLE
Fix alternative syntax request example

### DIFF
--- a/xAPI-Communication.md
+++ b/xAPI-Communication.md
@@ -2197,8 +2197,11 @@ Content:
 Request using alternative syntax:
 
 ```
-URL: http://example.com/xAPI/statements?method=PUT&statementId=c70c2b85-c294-464f-baca-cebd4fb9b348
+URL: http://example.com/xAPI/statements
 Method: POST
+
+Query String Parameters:
+    method=PUT
 
 Request Headers:
     Accept:*/*


### PR DESCRIPTION
Fixes the alternative syntax request example in Appendix C: Cross Domain Request Example.

Section 1.3 Alternate Request Syntax states that: 

`
The Learning Record Provider MUST NOT include any other query string parameters on the request.
`